### PR TITLE
Add actionlint to path when downloaded in a GitHub Action

### DIFF
--- a/scripts/download-actionlint.bash
+++ b/scripts/download-actionlint.bash
@@ -74,4 +74,6 @@ echo "Done: $("${exe}" -version)"
 if [ -n "$GITHUB_ACTION" ]; then
     # On GitHub Actions, set executable path to output
     echo "::set-output name=executable::${exe}"
+    # and add it to the path
+    echo "${exe}" >> "$GITHUB_PATH"
 fi


### PR DESCRIPTION
This makes the Action environment better match the local environment, for tools which use `actionlint` locally and in a workflow.

I'm using [reviewdog](https://github.com/reviewdog/reviewdog), and I can configure `actionlint` to run the check locally in my `.reviewdog.yml`:
```
runner:
    actionlint:
    cmd: actionlint -no-color -oneline
    # actionlint is a Go program
    format: golint
```

but in an action, I need to specify the arguments & reviewdog format again:
```
      - name: Run actionlint
        env:
          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
          ${{ steps.get_actionlint.outputs.executable }} -no-color -oneline | reviewdog -reporter=github-pr-review -fail-on-error -f golint
```

because the `cmd` part in the `.reviewdog.yml` assumes the `actionlint` binary is in the path. I can just run a separate step like:
```
      - name: Add actionlint to path
        run: |
          echo "${{ steps.get_actionlint.outputs.executable }}" >> "$GITHUB_PATH"
```

But it looks like it's simple enough to do it from the download script, and I think it's safe.