### PR TITLE
migrate actions/setup-ruby to ruby/setup-ruby

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
       - run: gem install ronn
       - run: ronn ./man/actionlint.1.ronn
       - uses: actions/setup-go@v2


### PR DESCRIPTION
https://github.com/actions/setup-ruby is archived and no longer maintained.
GitHub recommends to use ruby/setup-ruby instead of it.

> Please note: This action is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the ruby/setup-ruby, which is being actively maintained by the official Ruby organization.