### PR TITLE
bump codecov/codecov-action@v2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      OS: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install dependencies on macOS
@@ -44,7 +46,9 @@ jobs:
       - run: go tool cover -func ./coverage.txt
       # Dog fooding 🐶
       - run: ./actionlint -color
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          env_vars: OS
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
`codecov/codecov-action@v2` is released and v2 is now deprecated.

> https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1
> Deprecration of v1
> On February 1, 2022, this version will be fully sunset and no longer function
> 
> Due to the deprecation of the underlying bash uploader, the Codecov GitHub Action has released v2 which will use the new uploader. You can learn more about our deprecation plan and the new uploader on our blog.
> 
> We will be restricting any updates to the v1 Action to security updates and hotfixes.

We should migrate from v1 to v2.