### PR TITLE
add rules discussion and discussion_comment

### DIFF
--- a/rule_events.go
+++ b/rule_events.go
@@ -75,6 +75,24 @@ func (rule *RuleEvents) checkWebhookEvent(event *WebhookEvent) {
 	case "delete":
 	case "deployment":
 	case "deployment_status":
+	case "discussion":
+		types = []string{
+			"opened",
+			"edited",
+			"deleted",
+			"transferred",
+			"pinned",
+			"unpinned",
+			"labeled",
+			"unlabeled",
+			"locked",
+			"unlocked",
+			"category_changed",
+			"answered",
+			"unanswered",
+		}
+	case "discussion_comment":
+		types = []string{"created", "edited", "deleted"}
 	case "fork":
 	case "gollum":
 	case "issue_comment":


### PR DESCRIPTION
Add new webhook events `discussion` and `discussion_comment`.

- discussion: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#discussion
- discussion_comment: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#discussion_comment