### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1780,7 +1780,7 @@ cases.
 | `2`    | The command failed due to invalid command line option   |
 | `3`    | The command failed due to some fatal error              |
 
-# Use actionlint as library
+# Use actionlint as a library
 
 actionlint can be used from Go programs. See [the documentation][apidoc] to know the list of all APIs. It contains
 workflow file parser built on top of `go-yaml/yaml`, expression `${{ }}` lexer/parser/checker, etc.

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ List of checks:
 - [Permissions](#permissions)
 
 Note that actionlint focuses on catching mistakes in workflow files. If you want some general code style checks, please consider
-to use a general YAML checker like [yamllint][].
+using a general YAML checker like [yamllint][].
 
 <a name="check-unexpected-keys"></a>
 ## Unexpected keys

--- a/README.md
+++ b/README.md
@@ -1825,8 +1825,8 @@ library, meant that patch version bump may introduce some breaking changes.
 
 # Bug reporting
 
-When you 're seeing some bugs or false positives, it is helpful to [file a new issue][issue-form] with a minimal example
-of input. Giving me some feedbacks like feature requests or idea of additional checks is also welcome.
+When you see some bugs or false positives, it is helpful to [file a new issue][issue-form] with a minimal example
+of input. Giving me some feedbacks like feature requests or ideas of additional checks is also welcome.
 
 # References
 

--- a/README.md
+++ b/README.md
@@ -839,7 +839,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo 'parepare something'
-      # ERROR: Outputs in other job is not accessble
+      # ERROR: Outputs in other job is not accessible
       - run: echo '${{ needs.prepare.outputs.prepared }}'
   build:
     needs: [install, prepare]


### PR DESCRIPTION
素晴らしいツールに揚げ足取りのようなリクエストを送ってしまって恐縮です

これ以外にも、 workflow や job という単語がよく出ていますが、GitHub Actions のドキュメントでは可算名詞として使われているものの、ここでは無冠詞で使われているのをいくつか見かけました。ただ、冠詞がついているところも多かったり（※）、コード内のコメントなどの至る所に登場するワードなので手を出すのをやめておきます。

※ 形容詞的用法（名詞の連続）により workflow や job に冠詞がいらない場合もあります。例：workflow files, job runners

また、今回の PR の趣旨が README の修正なのでずれますが、 コード内のコメントにも以下の明らかな誤植を見つけたので、ご報告いたします。

- linter.go の 202 行目 ... worflow (k 抜け)
- rule_job_needs.go の 29 行目 ... conifiguration (n の後に不要な i)