### PR TITLE
cron schedule `*/5 * * * *` should be accepted

### DIFF
--- a/rule_events.go
+++ b/rule_events.go
@@ -60,7 +60,7 @@ func (rule *RuleEvents) checkCron(spec *String) {
 	// (#14) https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events
 	//
 	// > The shortest interval you can run scheduled workflows is once every 5 minutes.
-	if diff <= 60.0*5 {
+	if diff < 60.0*5 {
 		rule.errorf(spec.Pos, "scheduled job runs too frequently. it runs once per %g seconds. the shortest interval is once every 5 minutes", diff)
 	}
 }

--- a/testdata/examples/cron_schedule_check.out
+++ b/testdata/examples/cron_schedule_check.out
@@ -1,2 +1,3 @@
 test.yaml:4:13: invalid CRON format "0 */3 * *" in schedule event: Expected exactly 5 fields, found 4: 0 */3 * * [events]
 test.yaml:6:13: scheduled job runs too frequently. it runs once per 60 seconds. the shortest interval is once every 5 minutes [events]
+test.yaml:11:13: scheduled job runs too frequently. it runs once per 240 seconds. the shortest interval is once every 5 minutes [events]

--- a/testdata/examples/cron_schedule_check.yaml
+++ b/testdata/examples/cron_schedule_check.yaml
@@ -5,6 +5,11 @@ on:
     # Interval of scheduled job is too small (job runs too frequently)
     - cron: '* */3 * * *'
 
+    # It's OK. The interval can be every 5 minutes.
+    - cron: '*/5 * * * *'
+    # It's bad. The interval can't be less than every 5 minutes.
+    - cron: '*/4 * * * *'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fixes https://github.com/rhysd/actionlint/issues/14#issuecomment-886716283
> It looks that 04696da warns */5 * * * *, however it's OK because the interval can be every 5 minutes.
