### PR TITLE
Add Docker image for pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,3 +95,20 @@ jobs:
       - run: make lint
       - name: Lint bash scripts
         run: shellcheck ./scripts/download-actionlint.bash ./playground/post-install.bash ./playground/deploy.bash
+  docker:
+    name: Test Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        id: image
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            GOLANG_VER=1.16
+          push: false
+      - name: Test Docker image
+        run: docker container run
+          --mount type=bind,source="$(pwd)",target=/mnt/app
+          --workdir /mnt/app
+          -- ${{ steps.image.outputs.digest }} --verbose

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,3 +42,21 @@ jobs:
           git -c user.email='41898282+github-actions[bot]@users.noreply.github.com' -c user.name='github-actions[bot]' commit -m "update version to $ver in download-actionlint.bash"
           git log -n 1
           git push
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            GOLANG_VER=1.16
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/actionlint:${GITHUB_REF#refs/tags/}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/actionlint:latest

--- a/.pre-commit-hook.yaml
+++ b/.pre-commit-hook.yaml
@@ -6,3 +6,10 @@
   types: ["yaml"]
   files: "^.github/workflows/"
   entry: actionlint
+- id: actionlint-docker
+  name: Lint GitHub Actions workflow file Docker
+  description: Runs actionlint Docker image to lint GitHub Actions workflow files
+  language: docker_image
+  types: ["yaml"]
+  files: "^.github/workflows/"
+  entry: rhysd/actionlint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+ARG GOLANG_VER=latest
+ARG ALPINE_VER=latest
+
+FROM golang:${GOLANG_VER} as builder
+WORKDIR /go/src/app
+COPY go.* *.go ./
+COPY cmd cmd/
+RUN go build ./cmd/actionlint
+
+FROM alpine:${ALPINE_VER}
+COPY --from=builder /go/src/app/actionlint /usr/local/bin/
+RUN apk add shellcheck py3-pyflakes
+USER guest
+ENTRYPOINT ["/usr/local/bin/actionlint"]

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -290,6 +290,15 @@ repos:
       - id: actionlint
 ```
 
+or alternatively, run actionlint with Docker:
+```yaml
+---
+repos:
+  - repo: https://github.com/rhysd/actionlint
+    rev: main
+    hooks:
+      - id: actionlint-docker
+```
 ---
 
 [Checks](checks.md) | [Installation](install.md) | [Configuration](config.md) | [Go API](api.md) | [References](reference.md)


### PR DESCRIPTION
Is making actionlint available as a Docker image a possibility?

This PR illustrates what the implementation could look like. An account on a Docker image repository is required.