### PR TITLE
Modify dockerhub url in usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -354,4 +354,4 @@ repos:
 [preinstall-ubuntu]: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 [pre-commit]: https://pre-commit.com
 [docker]: https://www.docker.com/
-[docker-image]: https://hub.docker.com/repository/docker/rhysd/actionlint
+[docker-image]: https://hub.docker.com/r/rhysd/actionlint


### PR DESCRIPTION
The original url

https://hub.docker.com/repository/docker/rhysd/actionlint

required user to log in, while the modified one

https://hub.docker.com/r/rhysd/actionlint

does not.
This change makes using docker images more accessible for users without docker account.