### PR TITLE
Fix shell name validation example and test

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1508,9 +1508,6 @@ jobs:
       - run: echo 'hello'
         # ERROR: 'powershell' is only available on Windows
         shell: powershell
-      - run: echo 'hello'
-        # OK: 'powershell' is only available on Windows
-        shell: powershell
   mac:
     runs-on: macos-latest
     defaults:
@@ -1527,6 +1524,9 @@ jobs:
       - run: echo 'hello'
         # ERROR: 'sh' is only available on Windows
         shell: sh
+      - run: echo 'hello'
+        # OK: 'powershell' is only available on Windows
+        shell: powershell
 ```
 
 Output:

--- a/testdata/examples/shell_name_validation.out
+++ b/testdata/examples/shell_name_validation.out
@@ -1,5 +1,4 @@
 test.yaml:8:16: shell name "dash" is invalid. available names are "bash", "pwsh", "python", "sh" [shell-name]
 test.yaml:11:16: shell name "powershell" is invalid on macOS or Linux. available names are "bash", "pwsh", "python", "sh" [shell-name]
-test.yaml:14:16: shell name "powershell" is invalid on macOS or Linux. available names are "bash", "pwsh", "python", "sh" [shell-name]
-test.yaml:20:16: shell name "fish" is invalid. available names are "bash", "pwsh", "python", "sh" [shell-name]
-test.yaml:30:16: shell name "sh" is invalid on Windows. available names are "bash", "cmd", "powershell", "pwsh", "python" [shell-name]
+test.yaml:17:16: shell name "fish" is invalid. available names are "bash", "pwsh", "python", "sh" [shell-name]
+test.yaml:27:16: shell name "sh" is invalid on Windows. available names are "bash", "cmd", "powershell", "pwsh", "python" [shell-name]

--- a/testdata/examples/shell_name_validation.yaml
+++ b/testdata/examples/shell_name_validation.yaml
@@ -9,9 +9,6 @@ jobs:
       - run: echo 'hello'
         # ERROR: 'powershell' is only available on Windows
         shell: powershell
-      - run: echo 'hello'
-        # OK: 'powershell' is only available on Windows
-        shell: powershell
   mac:
     runs-on: macos-latest
     defaults:
@@ -28,3 +25,6 @@ jobs:
       - run: echo 'hello'
         # ERROR: 'sh' is only available on Windows
         shell: sh
+      - run: echo 'hello'
+        # OK: 'powershell' is only available on Windows
+        shell: powershell


### PR DESCRIPTION
The [shell name validation check](https://github.com/rhysd/actionlint/blob/main/docs/checks.md#check-shell-names) documentation has the following example:

```yaml
  linux:
    runs-on: ubuntu-latest
    steps:
      - run: echo 'hello'
        # ERROR: Unavailable shell
        shell: dash
      - run: echo 'hello'
        # ERROR: 'powershell' is only available on Windows
        shell: powershell
      - run: echo 'hello'
        # OK: 'powershell' is only available on Windows
        shell: powershell
```

As done in this PR, the `OK: 'powershell' is only available on Windows` section should be moved to the Windows section.