### PR TITLE
Add id-token to allowed keys

### DIFF
--- a/rule_permissions.go
+++ b/rule_permissions.go
@@ -5,6 +5,7 @@ var allPermissionScopes = map[string]struct{}{
 	"checks":              {},
 	"contents":            {},
 	"deployments":         {},
+	"id-token":            {},
 	"issues":              {},
 	"metadata":            {},
 	"packages":            {},


### PR DESCRIPTION
OpenID / JWT integration needs id-token set in permissions. "Shipped" yesterday: https://github.com/github/roadmap/issues/249