### PR TITLE
remove deprecated `bottle :unneeded`

### DIFF
--- a/HomebrewFormula/actionlint.rb
+++ b/HomebrewFormula/actionlint.rb
@@ -7,7 +7,6 @@ class Actionlint < Formula
   homepage "https://github.com/rhysd/actionlint#readme"
   version "1.6.6"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
Remove `bottle :unneeded` from brew formula.

`bottle :unneeded` now provokes a warning from Homebrew:
`Warning: Calling bottle :unneeded is deprecated! There is no replacement.`