### PR TITLE
`name` is a valid property of `runner`

### DIFF
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -245,6 +245,7 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 	"steps": NewEmptyStrictObjectType(), // This value will be updated contextually
 	// https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context
 	"runner": NewStrictObjectType(map[string]ExprType{
+		"name":       StringType{},
 		"os":         StringType{},
 		"temp":       StringType{},
 		"tool_cache": StringType{},

--- a/testdata/examples/contexts_and_buitin_funcs.yaml
+++ b/testdata/examples/contexts_and_buitin_funcs.yaml
@@ -18,3 +18,6 @@ jobs:
       - run: echo "${{ contains(github.event.labels.*.name, 'enhancement') }}"
       # format() has special check for formating string
       - run: echo "${{ format('{0}{1}', 1, 2, 3) }}"
+      # Runner metadata
+      - run: echo '${{ runner.os }}'
+      - run: echo '${{ runner.name }}'


### PR DESCRIPTION
Not sure when it showed up on github.com, but `runner.name` has been available since at least GHE 2.22, the first GHE release with Actions.
https://docs.github.com/en/enterprise-server@2.22/actions/learn-github-actions/contexts#runner-context

I wasn't sure where to put a test, so hope my choice is okay.
 
Thanks!