### PR TITLE
add actionlint asdf plugin reference in the install.md documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -19,6 +19,24 @@ brew tap "rhysd/actionlint" "https://github.com/rhysd/actionlint"
 brew install actionlint
 ```
 
+## asdf
+
+You can install actionlint with the [asdf version manager](https://asdf-vm.com/) using this [plugin](https://github.com/crazy-matt/asdf-actionlint), which automates the process of installing (and switching between) various versions of github release binaries. With asdf already installed, run these commands to install actionlint:
+
+```bash
+# Add actionlint plugin
+asdf plugin add actionlint
+
+# Show all installable versions
+asdf list-all actionlint
+
+# Install specific version
+asdf install actionlint latest
+
+# Set a version globally (on your ~/.tool-versions file)
+asdf global actionlint latest
+```
+
 ## Prebuilt binaries
 
 Download an archive file from [the releases page][releases] for your platform, unarchive it and put the executable file to a


### PR DESCRIPTION
Hi guys,

I created an `asdf` plugin for your linter.
You'll find below the current PR made againt the asdf plugin repository to be able to install actionlint just by name reference (without having to pass the plugin git repo url): 
https://github.com/asdf-vm/asdf-plugins/pull/530