### PR TITLE
introduce the `runner.arch` context value

### DIFF
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -250,6 +250,7 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 	"runner": NewStrictObjectType(map[string]ExprType{
 		"name":       StringType{},
 		"os":         StringType{},
+		"arch":       StringType{},
 		"temp":       StringType{},
 		"tool_cache": StringType{},
 		// These are not documented but actually exist


### PR DESCRIPTION
I found that a new context value `runner.arch` is available.

ref. https://docs.github.com/en/actions/learn-github-actions/contexts#runner-context

<img width="749" alt="the `runner.arch` context value" src="https://user-images.githubusercontent.com/1157344/147850771-8b998f6e-315a-4d25-83b9-7876c2ac14fc.png">
