### PR TITLE
fix: allow local paths for reusable workflows

### DIFF
--- a/linter_test.go
+++ b/linter_test.go
@@ -160,6 +160,7 @@ func TestLinterLintError(t *testing.T) {
 				}
 
 				if len(errs) != len(expected) {
+					fmt.Printf("File: %s", base)
 					t.Fatalf("%d errors are expected but actually got %d errors: %# v", len(expected), len(errs), errs)
 				}
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -160,7 +160,6 @@ func TestLinterLintError(t *testing.T) {
 				}
 
 				if len(errs) != len(expected) {
-					fmt.Printf("File: %s", base)
 					t.Fatalf("%d errors are expected but actually got %d errors: %# v", len(expected), len(errs), errs)
 				}
 

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -55,7 +55,7 @@ func (rule *RuleWorkflowCall) VisitJobPre(n *Job) error {
 	return nil
 }
 
-// Parse {owner}/{repo}/{path to workflow.yml}@{ref} or ./{path to workflow.yml}
+// Parse {owner}/{repo}/{path to workflow.yml}@{ref} or ./.github/workflows/{path to workflow.yml}
 // https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow
 func checkWorkflowCallUsesFormat(u string) bool {
 	if strings.HasPrefix(u, localPathPrefix) {

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -60,9 +60,7 @@ func (rule *RuleWorkflowCall) VisitJobPre(n *Job) error {
 func checkWorkflowCallUsesFormat(u string) bool {
 	if strings.HasPrefix(u, localPathPrefix) {
 		return len(u) > len(localPathPrefix)
-	}
-
-	if strings.HasPrefix(u, ".") {
+	} else if strings.HasPrefix(u, ".") {
 		return false // Other local paths are not supported.
 	}
 

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -51,11 +51,11 @@ func (rule *RuleWorkflowCall) VisitJobPre(n *Job) error {
 	return nil
 }
 
-// Parse {owner}/{repo}/{path to workflow.yml}@{ref}
+// Parse {owner}/{repo}/{path to workflow.yml}@{ref} or ./{path to workflow.yml}
 // https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow
 func checkWorkflowCallUsesFormat(u string) bool {
 	if strings.HasPrefix(u, ".") {
-		return false // Local path is not supported.
+		return true // Local paths have no known path components to validate.
 	}
 
 	idx := strings.IndexRune(u, '/')

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -4,6 +4,10 @@ import (
 	"strings"
 )
 
+const (
+	localPathPrefix = "./.github/workflows/"
+)
+
 // RuleWorkflowCall is a rule checker to check workflow call at jobs.<job_id>.
 type RuleWorkflowCall struct {
 	RuleBase
@@ -54,8 +58,12 @@ func (rule *RuleWorkflowCall) VisitJobPre(n *Job) error {
 // Parse {owner}/{repo}/{path to workflow.yml}@{ref} or ./{path to workflow.yml}
 // https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow
 func checkWorkflowCallUsesFormat(u string) bool {
+	if strings.HasPrefix(u, localPathPrefix) {
+		return len(u) > len(localPathPrefix)
+	}
+
 	if strings.HasPrefix(u, ".") {
-		return true // Local paths have no known path components to validate.
+		return false // Other local paths are not supported.
 	}
 
 	idx := strings.IndexRune(u, '/')

--- a/rule_workflow_call_test.go
+++ b/rule_workflow_call_test.go
@@ -15,6 +15,7 @@ func TestRuleWorkflowCallCheckWorkflowCallUsesFormat(t *testing.T) {
 		{"owner/repo/x.yml@release/v1", true},
 		{"${{ env.FOO }}", true},
 		{"./path/to/x.yml@ref", false},
+		{"./.github/workflows/x.yml", true},
 		{"/path/to/x.yml@ref", false},
 		{"owner/x.yml@ref", false},
 		{"owner/repo@ref", false},

--- a/testdata/examples/workflow_call_jobs.out
+++ b/testdata/examples/workflow_call_jobs.out
@@ -1,3 +1,3 @@
 test.yaml:6:5: when a reusable workflow is called with "uses", "runs-on" is not available. only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", and "permissions" in job "job1" [syntax-check]
-test.yaml:9:11: reusable workflow call "./.github/workflows/ci.yml@main" at "uses" is not following the format "owner/repo/path/to/workflow.yml@ref". see https://docs.github.com/en/actions/learn-github-actions/reusing-workflows for more details [workflow-call]
-test.yaml:12:5: "with" is only available for a reusable workflow call with "uses" but "uses" is not found in job "job3" [syntax-check]
+test.yaml:12:11: reusable workflow call ".github/workflows/ci.yml" at "uses" is not following the format "owner/repo/path/to/workflow.yml@ref". see https://docs.github.com/en/actions/learn-github-actions/reusing-workflows for more details [workflow-call]
+test.yaml:15:5: "with" is only available for a reusable workflow call with "uses" but "uses" is not found in job "job4" [syntax-check]

--- a/testdata/examples/workflow_call_jobs.yaml
+++ b/testdata/examples/workflow_call_jobs.yaml
@@ -5,9 +5,12 @@ jobs:
     # ERROR: 'runs-on' is not available on calling reusable workflow
     runs-on: ubuntu-latest
   job2:
-    # ERROR: Local file path is not available
-    uses: ./.github/workflows/ci.yml@main
+    # OK: Local file path is valid
+    uses: ./.github/workflows/ci.yml
   job3:
+    # ERROR: Local file path is the wrong format
+    uses: .github/workflows/ci.yml
+  job4:
     # ERROR: 'with' is only available on calling reusable workflow
     with:
       foo: bar


### PR DESCRIPTION
fixes #114

Currently, the linter throws an error for calls to a local workflow file. However, local workflow files are perfectly valid, and the pattern is encouraged by GitHub documentation:

> You reference reusable workflow files using one of the following syntaxes:
> - {owner}/{repo}/{path}/{filename}@{ref} for reusable workflows in public repositories.
> - **/{path}/{filename} for reusable workflows in the same repository.**

https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow