### PR TITLE
Add configurable rule to avoid overlong inline `run:` scripts

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 		// Labels is label names for self-hosted runner.
 		Labels []string `yaml:"labels"`
 	} `yaml:"self-hosted-runner"`
+	RunScriptMaxLines *int `yaml:"run-script-max-lines",omitempty`
 }
 
 func parseConfig(b []byte, path string) (*Config, error) {
@@ -39,6 +40,8 @@ func writeDefaultConfigFile(path string) error {
 	b := []byte(`self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels: []
+
+#run-script-max-lines: 23
 `)
 	if err := ioutil.WriteFile(path, b, 0644); err != nil {
 		return fmt.Errorf("could not write default configuration file at %q: %w", path, err)

--- a/linter.go
+++ b/linter.go
@@ -457,8 +457,12 @@ func (l *Linter) check(path string, content []byte, project *Project, proc *conc
 		dbg := l.debugWriter()
 
 		var labels []string
+		var maxLines int = 10
 		if cfg != nil {
 			labels = cfg.SelfHostedRunner.Labels
+			if cfg.RunScriptMaxLines != nil {
+				maxLines = *cfg.RunScriptMaxLines
+			}
 		}
 
 		rules := []Rule{
@@ -475,6 +479,7 @@ func (l *Linter) check(path string, content []byte, project *Project, proc *conc
 			NewRulePermissions(),
 			NewRuleWorkflowCall(),
 			NewRuleExpression(localActions),
+			NewRuleRunScriptLength(maxLines),
 		}
 		if l.shellcheck != "" {
 			r, err := NewRuleShellcheck(l.shellcheck, proc)

--- a/rule_run_script_length.go
+++ b/rule_run_script_length.go
@@ -1,0 +1,43 @@
+package actionlint
+
+import "strings"
+
+// RuleRunScriptLength is a rule to check the 'run' field does not contain too long scripts.
+type RuleRunScriptLength struct {
+	RuleBase
+	maxLines int
+}
+
+// NewRuleRunScriptLength creates new RuleRunScriptLength instance.
+func NewRuleRunScriptLength(maxLines int) *RuleRunScriptLength {
+	return &RuleRunScriptLength{
+		RuleBase: RuleBase{name: "run-script-length"},
+		maxLines: maxLines,
+	}
+}
+
+// VisitStep is callback when visiting Step node.
+func (rule *RuleRunScriptLength) VisitStep(n *Step) error {
+	if run, ok := n.Exec.(*ExecRun); ok {
+		rule.checkRunScriptLength(run.Run)
+	}
+	return nil
+}
+
+func (rule *RuleRunScriptLength) checkRunScriptLength(node *String) {
+	if node == nil {
+		return
+	}
+
+	numberOfLines := strings.Count(node.Value, "\n")
+
+	if numberOfLines <= rule.maxLines {
+		return
+	}
+
+	rule.errorf(
+		node.Pos,
+		"run script has too many lines (%d), prefer outsourcing into a standalone script",
+		numberOfLines,
+	)
+}


### PR DESCRIPTION
Hi, this is my first contribution here since I wanted to learn how to add new rules. I'm prepared to iterate on the idea (which is opinionated) if maintainers like it.

Motivation: sometimes I see / author GHA workflows that have long bash scripts (more than a dozen lines) in `run:` steps. This makes the overall workflow harder to read.
It also makes `shellcheck` warnings from reported by actionlint more difficult to interpret due to the "nested" line numbers - I first need to figure out which `run:` step it is about and then which line inside that step `shellcheck` complains. This gets a bit easier when the scripts are shorter.

Usually short scripts can be achieved by refactoring into separate `.sh` files or build systems (`Makefile` etc.). This is why I'm proposing the idea that actionlint could detect those situations.

I also added a configuration parameter since the amount of lines where to make the cut is probably subjective.

Please tell me what you think! No hard feelings if you think it is too opinionated 😄 

PS: [build](https://github.com/cmur2/actionlint/actions/runs/1898186503) in my fork is green.