### PR TITLE
add stdin-filename support

### DIFF
--- a/command.go
+++ b/command.go
@@ -98,8 +98,8 @@ func (cmd *Command) runLinter(args []string, opts *LinterOptions, initConfig boo
 			return nil, fmt.Errorf("could not read stdin: %w", err)
 		}
 		n := "<stdin>"
-		if opts.StdInFileName != "" {
-			n = opts.StdInFileName
+		if opts.StdinFileName != "" {
+			n = opts.StdinFileName
 		}
 		return l.Lint(n, b, nil)
 	}
@@ -142,7 +142,7 @@ func (cmd *Command) Main(args []string) int {
 	flags.BoolVar(&opts.Verbose, "verbose", false, "Enable verbose output")
 	flags.BoolVar(&opts.Debug, "debug", false, "Enable debug output (for development)")
 	flags.BoolVar(&ver, "version", false, "Show version and how this binary was installed")
-	flags.StringVar(&opts.StdInFileName, "stdin-filename", "", "File name for stdin")
+	flags.StringVar(&opts.StdinFileName, "stdin-filename", "", "File name for stdin")
 	flags.Usage = func() {
 		fmt.Fprintln(cmd.Stderr, commandUsageHeader)
 		flags.PrintDefaults()

--- a/command.go
+++ b/command.go
@@ -97,11 +97,11 @@ func (cmd *Command) runLinter(args []string, opts *LinterOptions, initConfig boo
 		if err != nil {
 			return nil, fmt.Errorf("could not read stdin: %w", err)
 		}
-		if opts.StdInFileName == "" {
-			return l.Lint("<stdin>", b, nil)
-		} else {
-			return l.Lint(opts.StdInFileName, b, nil)
+		n := "<stdin>"
+		if opts.StdInFileName != "" {
+			n = opts.StdInFileName
 		}
+		return l.Lint(n, b, nil)
 	}
 
 	return l.LintFiles(args, nil)

--- a/command.go
+++ b/command.go
@@ -97,7 +97,11 @@ func (cmd *Command) runLinter(args []string, opts *LinterOptions, initConfig boo
 		if err != nil {
 			return nil, fmt.Errorf("could not read stdin: %w", err)
 		}
-		return l.Lint("<stdin>", b, nil)
+		if opts.StdInFileName == "" {
+			return l.Lint("<stdin>", b, nil)
+		} else {
+			return l.Lint(opts.StdInFileName, b, nil)
+		}
 	}
 
 	return l.LintFiles(args, nil)
@@ -138,6 +142,7 @@ func (cmd *Command) Main(args []string) int {
 	flags.BoolVar(&opts.Verbose, "verbose", false, "Enable verbose output")
 	flags.BoolVar(&opts.Debug, "debug", false, "Enable debug output (for development)")
 	flags.BoolVar(&ver, "version", false, "Show version and how this binary was installed")
+	flags.StringVar(&opts.StdInFileName, "stdin-filename", "", "File name for stdin")
 	flags.Usage = func() {
 		fmt.Fprintln(cmd.Stderr, commandUsageHeader)
 		flags.PrintDefaults()

--- a/linter.go
+++ b/linter.go
@@ -79,6 +79,8 @@ type LinterOptions struct {
 	// Format is a custom template to format error messages. It must follow Go Template format and
 	// contain at least one {{ }} placeholder. https://pkg.go.dev/text/template
 	Format string
+	// Set FileName for stdin
+	StdInFileName string
 	// More options will come here
 }
 

--- a/linter.go
+++ b/linter.go
@@ -80,7 +80,7 @@ type LinterOptions struct {
 	// contain at least one {{ }} placeholder. https://pkg.go.dev/text/template
 	Format string
 	// Set FileName for stdin
-	StdInFileName string
+	StdinFileName string
 	// More options will come here
 }
 


### PR DESCRIPTION
## What
add support for overwriting file names when using stdin.
## Why
When I tried developing a VSCode extension for actionlint, I felt it would be helpful if we had this option.
FYI: https://github.com/fnando/vscode-linter/blob/main/docs/creating-linters.md


For example, eslint has this kind of option. https://eslint.org/docs/user-guide/command-line-interface#--stdin-filename
## QA
With --stdin-filename 
```
shun@Mac-mini actionlint % echo "foo"|  ./actionlint --stdin-filename "test.yml" -
test.yml:1:1: workflow is scalar node but mapping node is expected [syntax-check]
  |
1 | foo
  | ^~~
test.yml:1:1: "jobs" section is missing in workflow [syntax-check]
  |
1 | foo
  | ^~~
```
Without --stdin-filename 
```
shun@Mac-mini actionlint % echo "foo"|  ./actionlint -
<stdin>:1:1: workflow is scalar node but mapping node is expected [syntax-check]
  |
1 | foo
  | ^~~
<stdin>:1:1: "jobs" section is missing in workflow [syntax-check]
  |
1 | foo
  | ^~~
```
