### PR TITLE
Fix install script version override

### DIFF
--- a/scripts/download-actionlint.bash
+++ b/scripts/download-actionlint.bash
@@ -47,7 +47,7 @@ version="1.6.14"
 if [ -n "$1" ]; then
     if [[ "$1" != 'latest' && "$1" != 'LATEST' ]]; then
         if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="1.6.14"
+            version="$1"
         else
             echo "Given version '$1' does not match to regex '^[0-9]+\.[0-9]+\.[0-9]+$' nor equal to 'latest'" >&2
             echo >&2


### PR DESCRIPTION
The install script (suggested to be used in CI pipelines) supports
version overrides. This is especially useful in environments where tools
and dependencies need to be pinned to a certain version. It seems this
has been accidentally changed by an automated CI process during the
latest release; version overrides no longer work, and instead, only the
most recent release (`v1.6.14`) can be used.

This change fixes the accidental commit by using the provided program
argument instead of the hardcoded value when an overridden version is
provided to `actionlint`.

Closes #161

Signed-off-by: Matei David <matei@buoyant.io>


---

### Tests

* Behaviour prior to the change:

```sh
# 
#  Curl script and execute
# 
:; cd /Downloads

:;  curl -s curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- 1.6.13 tmp/
Start downloading actionlint v1.6.14 to tmp
Detected OS=linux ext=tar.gz arch=amd64
Downloaded and unarchived executable: tmp/actionlint
Done: 1.6.14
installed by downloading from release page
built with go1.18.3 compiler for linux/amd64

:; cd tmp/

:; ./actionlint --version
1.6.14
installed by downloading from release page
built with go1.18.3 compiler for linux/amd64

```


* Behaviour after the change:

```sh
:; ./download-actionlint.bash 1.6.13 tmp/
Start downloading actionlint v1.6.13 to tmp
Detected OS=linux ext=tar.gz arch=amd64
Downloaded and unarchived executable: tmp/actionlint
Done: 1.6.13
installed by downloading from release page
built with go1.18.1 compiler for linux/amd64

:; ./actionlint --version
1.6.13
installed by downloading from release page
built with go1.18.1 compiler for linux/amd64
```

Apologies if the contribution was very straightforward. I'm working on integrating `actionlint` in our pipeline and would rather use the install script as opposed to just curling the latest binary from the release page. Let me know if anything needs to be changed :) 