### PR TITLE
ci: Fix step to update version in install script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           set -x
           ver="${GITHUB_REF#refs/tags/v}"
           cd ./tmp-actionlint-for-update-ver
-          sed -i -E "s/version=\"[^\"]+\"/version=\"${ver}\"/" ./scripts/download-actionlint.bash
+          sed -i -E "0,/version=\"[^\"]+\"/s//version=\"${ver}\"/" ./scripts/download-actionlint.bash
           git diff
           git add ./scripts/download-actionlint.bash
           git -c user.email='41898282+github-actions[bot]@users.noreply.github.com' -c user.name='github-actions[bot]' commit -m "update version to $ver in download-actionlint.bash"


### PR DESCRIPTION
When releasing, it seems that the GitHub Action step responsible for
updating the latest version in the download (/install) script will
replace all occurences of `version=` with the new release version.

The step has a slight hint of undefined behaviour whereby the `sed`
command that replaces the pinned version will end up replacing the
version override variable too. This means that every release,
`download-actionlint` will be broken and will not work with version
overrides. This can have consequences to environments where operators
rely on pinned versions of `actionlint`.

The introduced change alters the `sed` command in the release workflow
to only change the first occurence of the searchterm.

Signed-off-by: Matei David <matei@buoyant.io>

---

I haven't really tested the workflow out (we haven't yet figured how to test release workflows, but would be happy to find out if people _can_ do it :D ).

I thought fixing the problem might not be enough so I decided to do some spelunking in the repo's workflows. I think the easiest change to fix this issue is to only change the first occurrence of `version=\"[^\"]+\"`. This should leave the part where we override version with `"$1"` untouched.

```sh
# Before
 sed -i -E "s/version=\"[^\"]+\"/version=\"1.6.13\"/" ./scripts/download-actionlint.bash
-version="1.6.14"
+version="1.6.13"
 if [ -n "$1" ]; then
     if [[ "$1" != 'latest' && "$1" != 'LATEST' ]]; then
         if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            version="1.6.14"
+            version="1.6.13"
         else

# Both instances of "version=<ver>" are changed.
```

```sh
# After
sed -i -E "0,/version=\"[^\"]+\"/s//version=\"1.6.13\"/" scripts/download-actionlint.bash
-version="1.6.14"
+version="1.6.13"
 if [ -n "$1" ]; then
     if [[ "$1" != 'latest' && "$1" != 'LATEST' ]]; then
         if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
            version="1.6.14" # version as seen in latest main branch

# Only first instance is changed, override stays the same
```

```
0,/version=\"[^\"]+\"/s//version=\"1.6.13\"/" scripts/download-actionlint.bash
```

The script's form this way basically means:

From `0` (start of file) until the first occurence of `version=<version>`, replace `version=<version` (s//). I'm terrible at bash, and probably even more so at using `sed`. Credits go to [the stackoverflow community](https://stackoverflow.com/questions/148451/how-to-use-sed-to-replace-only-the-first-occurrence-in-a-file).
