### PR TITLE
fix: fix validation of github.triggering_actor

### DIFF
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -215,6 +215,7 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 		"server_url":       StringType{},
 		"sha":              StringType{},
 		"token":            StringType{},
+		"triggering_actor": StringType{},
 		"workflow":         StringType{},
 		"workspace":        StringType{},
 		// Below props are not documented but actually exist


### PR DESCRIPTION
`github` not just exposes `actor`, but also `triggering_actor`.