### PR TITLE
Enforce empty permissions

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -31,6 +31,15 @@ func (p *Pos) IsBefore(other *Pos) bool {
 	return p.Col < other.Col
 }
 
+// IsTopLevel returns true if we are on the top level of the yaml
+// for example:
+// name: Test
+// on: push
+// `on` and `name` are on the top level
+func (p *Pos) IsTopLevel() bool {
+	return p.Col == 1
+}
+
 // String represents generic string value in YAML file with position.
 type String struct {
 	// Value is a raw value of the string.

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 		// Labels is label names for self-hosted runner.
 		Labels []string `yaml:"labels"`
 	} `yaml:"self-hosted-runner"`
+	EnforceEmptyPermissions bool `yaml:"enforce_empty_permissions"`
 }
 
 func parseConfig(b []byte, path string) (*Config, error) {
@@ -39,6 +40,7 @@ func writeDefaultConfigFile(path string) error {
 	b := []byte(`self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels: []
+  enforce_empty_permissions: false
 `)
 	if err := os.WriteFile(path, b, 0644); err != nil {
 		return fmt.Errorf("could not write default configuration file at %q: %w", path, err)

--- a/config_test.go
+++ b/config_test.go
@@ -40,6 +40,11 @@ func TestConfigParseOK(t *testing.T) {
 			input:  "self-hosted-runner:\n  labels: [foo, bar]",
 			labels: []string{"foo", "bar"},
 		},
+		{
+			what:   "enforce empty permissions",
+			input:  "enforce_empty_permissions: true \n",
+			labels: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,9 +19,10 @@ actionlint -init-config
 vim .github/actionlint.yaml
 ```
 
-Currently only one item can be configured.
+Currently only two items can be configured.
 
 ```yaml
+enforce_empty_permissions: false
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
@@ -29,7 +30,7 @@ self-hosted-runner:
     - windows-latest-xl
     - linux-multi-gpu
 ```
-
+- `enforce_empty_permissions`: Enforces empty permissions at top level
 - `self-hosted-runner`: Configuration for your self-hosted runner environment
   - `labels`: Label names added to your self-hosted runners as list of string
 

--- a/linter.go
+++ b/linter.go
@@ -459,7 +459,7 @@ func (l *Linter) check(path string, content []byte, project *Project, proc *conc
 		l.debug("No config was found")
 	}
 
-	w, all := Parse(content)
+	w, all := Parse(content, cfg)
 
 	if l.logLevel >= LogLevelVerbose {
 		elapsed := time.Since(start)

--- a/testdata/ok/empty_permissions.yaml
+++ b/testdata/ok/empty_permissions.yaml
@@ -1,0 +1,12 @@
+on: push
+
+permissions: {}
+
+jobs:
+ test:
+   runs-on: ubuntu-latest
+   permissions:
+     contents: read
+   steps:
+     - name: test
+       run: echo "hello"


### PR DESCRIPTION
## Description 

Following the [Security Hardening for Github Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) guide, they mention the use of permissions. 

Permissions should be given as needed, and have them write-all should be avoided. 

One way to accomplish this recommendation is to set the global permissions to none, and give on demand to the jobs that need it.

## Implementation details

Enforcing such approach perhaps is not desired for everyone, so I added a configuration option. The default values is `false`, which keeps the current behaviour, but if the user sets it to `true`, then, the linter will check the top level for empty permissions.

## Considerations

I added a example yaml, which is correct workflow file, but that's where the test end. Please let me know if you want more tests, for example different variations of the permissions array, I'll gladly add them.

## Related Issues

Tries to solve, at least partially, one of the aspects discussed in #198 