### PR TITLE
Add `run-name` to expected keys for `workflow` section

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -1289,6 +1289,7 @@ func (p *parser) parse(n *yaml.Node) *Workflow {
 		default:
 			p.unexpectedKey(k, "workflow", []string{
 				"name",
+				"run-name",
 				"on",
 				"permissions",
 				"env",


### PR DESCRIPTION
Fixes #230