### PR TITLE
Replace deprecated `::set-output` command

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -29,10 +29,10 @@ jobs:
       - run: go generate
       - run: |
           if git diff-files --quiet; then
-            echo '::set-output name=pr::false'
+            echo "pr=false" >> "$GITHUB_OUTPUT"
           else
             git diff
-            echo '::set-output name=pr::true'
+            echo "pr=true" >> "$GITHUB_OUTPUT"
           fi
         id: diff
       - uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Get tag name
         id: tag
         run: |
-          echo "::set-output name=name::${GITHUB_REF#refs/tags/v}"
+          echo "name=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -443,7 +443,7 @@ jobs:
       # ERROR: Access undefined step outputs
       - run: echo '${{ steps.get_value.outputs.name }}'
       # Outputs are set here
-      - run: echo '::set-output name=foo::value'
+      - run: echo "foo=value" >> "$GITHUB_OUTPUT"
         id: get_value
       # OK
       - run: echo '${{ steps.get_value.outputs.name }}'

--- a/scripts/download-actionlint.bash
+++ b/scripts/download-actionlint.bash
@@ -132,5 +132,5 @@ echo "Done: $("${exe}" -version)"
 
 if [ -n "$GITHUB_ACTION" ]; then
     # On GitHub Actions, set executable path to output
-    echo "::set-output name=executable::${exe}"
+    echo "executable=${exe}" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/test-download-actionlint.bash
+++ b/scripts/test-download-actionlint.bash
@@ -21,7 +21,7 @@ set -e
 # No arguments
 out="$(bash "$script")"
 if [ -n "$GITHUB_ACTION" ]; then
-    if [[ "$out" != *"::set-output name=executable::"* ]]; then
+    if [[ "$out" != *"executable="* ]]; then
         echo "'executable' step output is not set: '${out}'" >&2
     fi
 fi

--- a/testdata/examples/contextual_steps_outputs.yaml
+++ b/testdata/examples/contextual_steps_outputs.yaml
@@ -9,7 +9,7 @@ jobs:
       # Access undefined step outputs
       - run: echo '${{ steps.get_value.outputs.name }}'
       # Outputs are set here
-      - run: echo '::set-output name=foo::value'
+      - run: echo "foo=value" >> "$GITHUB_OUTPUT"
         id: get_value
       # OK
       - run: echo '${{ steps.get_value.outputs.name }}'

--- a/testdata/ok/no_description_workflow_call.yaml
+++ b/testdata/ok/no_description_workflow_call.yaml
@@ -18,6 +18,6 @@ jobs:
       output1: ${{ steps.step1.outputs.firstword }}
     steps:
       - id: step1
-        run: echo "::set-output name=firstword::hello, ${{ inputs.username }}"
+        run: echo "firstword=hello, ${{ inputs.username }}" >> "$GITHUB_OUTPUT"
         env:
           TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
As mentioned in #234, the `::set-output` is deprecated. This would cause warnings to show up when using the installation script. I've replaced it in that script, as well as all the other usages of `::set-output` I could find.