### PR TITLE
Make the playground's right pane content sticky

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ workflow. Runs can be checked [here](https://github.com/rhysd/actionlint/actions
 
 ## Maintain `all_webhooks.go`
 
-[`all_webhooks.go`(./all_webhooks.go) is a table all webhooks supported by GitHub Actions to trigger workflows. Note that
+[`all_webhooks.go`](./all_webhooks.go) is a table all webhooks supported by GitHub Actions to trigger workflows. Note that
 not all webhooks are supported by GitHub Actions.
 
 It is generated automatically with `go generate`. The command runs [`generate-webhook-events`](./scripts/generate-webhook-events)

--- a/playground/index.html
+++ b/playground/index.html
@@ -44,14 +44,14 @@
     <main>
       <div id="editor" class="split-pane"></div>
       <div class="split-pane">
-        <div id="loading" class="notification has-text-centered is-size-5">Loading WebAssembly binary...</div>
-        <table id="lint-result" class="table is-hoverable">
+        <div id="loading" class="notification sticky has-text-centered is-size-5">Loading WebAssembly binary...</div>
+        <table id="lint-result" class="table sticky is-hoverable">
           <tbody id="lint-result-body">
           </tbody>
         </table>
-        <div id="error-msg" class="notification is-danger is-light is-size-5">
+        <div id="error-msg" class="notification sticky is-danger is-light is-size-5">
         </div>
-        <div id="success-msg" class="notification is-success is-light is-size-5">Yay! No error was detected.</div>
+        <div id="success-msg" class="notification sticky is-success is-light is-size-5">Yay! No error was detected.</div>
       </div>
     </main>
     <footer class="footer">

--- a/playground/style.css
+++ b/playground/style.css
@@ -62,6 +62,11 @@ main {
   cursor: pointer;
 }
 
+.sticky {
+  position: sticky;
+  top: 0;
+}
+
 footer {
   margin-top: 32px;
 }


### PR DESCRIPTION
Put this together quickly after pasting a workflow file into the playground and being briefly confused that the lint results disappeared (they were at the top of the page).

This updates the styling on the content of the [playground](https://rhysd.github.io/actionlint/)'s right pane to be sticky so that it stays in view when at the bottom of a long workflow file:

[sticky right pane preview](https://user-images.githubusercontent.com/3742559/205741762-497e264e-817a-4936-9e4f-f9ed03c27224.webm)

Note that this is arguably worse UX if there's many lint results (and a long workflow file) as you now have to scroll past the entire workflow file to get to the lint results near the bottom:

[many lint results preview](https://user-images.githubusercontent.com/3742559/205742868-5055e2c1-ed3f-446d-ba72-2640281257da.webm)


I also included a fix for a link in the contributing guidelines.