### PR TITLE
Make Actionlint Directly Invokable as an Action Itself 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: "Report Invalid Color Input"
       if: inputs.color != 'yes' && inputs.color != 'true' && inputs.color != 'no' && inputs.color != 'false'
       shell: bash
-      run: echo "::warning::Invalid boolean value for color: ${{ format('{0}', inputs.color) }}"
+      run: echo ${{ format('::warning::Invalid boolean value for color: {0}', inputs.color) }}
 
     - name: "Download Action Lint"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,23 @@ description: ":octocat: Static checker for GitHub Actions workflow files"
 #  icon: _
 #  color: _
 
+inputs:
+  color:
+    default: false
+    description: "Enable colorful output."
+
 runs:
   using: composite
   steps:
+    - name: "Report Invalid Color Input"
+      if: inputs.color != 'yes' && inputs.color != 'true' && inputs.color != 'no' && inputs.color != 'false'
+      shell: bash
+      run: echo "::warning::Invalid boolean value for color: ${{ format({0}, inputs.color) }}"
+
     - name: "Download Action Lint"
       shell: bash
       run: ${{ github.action_path }}/scripts/download-actionlint.bash latest ${{ runner.temp }}
 
     - name: "Run Action Lint"
       shell: bash
-      run: ${{ runner.temp }}/actionlint -color
+      run: ${{ runner.temp }}/actionlint ${{ inputs.color == 'yes' || inputs.color == 'true' && '-color' }}

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ runs:
 
     - name: "Run Action Lint"
       shell: bash
-      run: ${{ runner.temp }}/actionlint ${{ inputs.color == 'yes' || inputs.color == 'true' && '-color' }}
+      run: ${{ runner.temp }}/actionlint ${{ (inputs.color == 'yes' || inputs.color == 'true') && '-color' || '' }}

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: "Report Invalid Color Input"
       if: inputs.color != 'yes' && inputs.color != 'true' && inputs.color != 'no' && inputs.color != 'false'
       shell: bash
-      run: echo ${{ format('::warning::Invalid boolean value for color: {0}', inputs.color) }}
+      run: echo ${{ format('::warning::Invalid boolean value for color "{0}"', inputs.color) }}
 
     - name: "Download Action Lint"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,19 @@
+---
+
+name: actionlint
+description: :octocat: Static checker for GitHub Actions workflow files
+
+#branding: # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
+#  icon: _
+#  color: _
+
+runs:
+  using: composite
+  steps:
+    - name: "Download Action Lint"
+      shell: bash
+      run: ${{ github.action_path }}/scripts/download-actionlint.bash latest ${{ runner.temp }}
+
+    - name: "Run Action Lint"
+      shell: bash
+      run: ${{ runner.temp }}/actionlint -color

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 ---
 
 name: actionlint
-description: :octocat: Static checker for GitHub Actions workflow files
+description: ":octocat: Static checker for GitHub Actions workflow files"
 
 #branding: # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
 #  icon: _

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: "Report Invalid Color Input"
       if: inputs.color != 'yes' && inputs.color != 'true' && inputs.color != 'no' && inputs.color != 'false'
       shell: bash
-      run: echo "::warning::Invalid boolean value for color: ${{ format({0}, inputs.color) }}"
+      run: echo "::warning::Invalid boolean value for color: ${{ format('{0}', inputs.color) }}"
 
     - name: "Download Action Lint"
       shell: bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -278,6 +278,21 @@ Go APIs are available. See [the Go API document](api.md) for more details.
 <a name="tools-integ"></a>
 ## Tools integration
 
+### GitHub Actions
+
+[actionlint](..) is itself integrated with GitHub Actions. It can be run directly from a simple workflow file.
+
+```yaml
+name: actionlint
+on: push
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rhysd/actionlint@v1.x.y
+```
+
 ### reviewdog
 
 [reviewdog][] is an automated review tool for various code hosting services. It officially [supports actionlint][reviewdog-actionlint].

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -309,6 +309,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: reviewdog/action-actionlint@v1
+        with:
+          color: true
 ```
 
 <a name="problem-matchers"></a>

--- a/scripts/download-actionlint.bash
+++ b/scripts/download-actionlint.bash
@@ -37,6 +37,29 @@ function usage() {
     echo '      $ bash download-actionlint.bash 1.6.9 /usr/bin' >&2
 }
 
+log() {
+    if [ "${GITHUB_ACTIONS}" ]
+    then
+        echo "::notice::$@"
+    else
+        echo "$@" 1>&2
+    fi
+}
+
+err() {
+    if [ "${GITHUB_ACTIONS}" ]
+    then
+        echo "::error::$@"
+    else
+        echo "$@" 1>&2
+    fi
+}
+
+die() {
+    err "$@"
+    exit 1
+}
+
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     usage
     exit

--- a/scripts/download-actionlint.bash
+++ b/scripts/download-actionlint.bash
@@ -72,7 +72,8 @@ if [ -n "$1" ]; then
         if [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             version="$1"
         else
-            echo "Given version '$1' does not match to regex '^[0-9]+\.[0-9]+\.[0-9]+$' nor equal to 'latest'" >&2
+            err "Given version '$1' does not match to regex '^[0-9]+\.[0-9]+\.[0-9]+$' nor equal to 'latest'"
+
             echo >&2
             usage
             exit 1
@@ -85,14 +86,15 @@ if [ -n "$2" ]; then
     if [ -d "$2" ]; then
         target_dir="${2%/}"
     else
-        echo "Directory '$2' does not exist" >&2
+        err "Directory '$2' does not exist"
+
         echo >&2
         usage
         exit 1
     fi
 fi
 
-echo "Start downloading actionlint v${version} to ${target_dir}"
+log "Start downloading actionlint v${version} to ${target_dir}"
 
 case "$OSTYPE" in
     linux-*)
@@ -112,8 +114,7 @@ case "$OSTYPE" in
         ext=zip
     ;;
     *)
-        echo "OS '${OSTYPE}' is not supported. Note: If you're using Windows, please ensure bash is used to run this script" >&2
-        exit 1
+        die "OS '${OSTYPE}' is not supported. Note: If you're using Windows, please ensure bash is used to run this script"
     ;;
 esac
 
@@ -125,18 +126,17 @@ case "$machine" in
     aarch64|arm64) arch=arm64 ;;
     arm*) arch=armv6 ;;
     *)
-        echo "Could not determine arch from machine hardware name '${machine}'" >&2
-        exit 1
+        die "Could not determine arch from machine hardware name '${machine}'"
     ;;
 esac
 
-echo "Detected OS=${os} ext=${ext} arch=${arch}"
+log "Detected OS=${os} ext=${ext} arch=${arch}"
 
 # https://github.com/rhysd/actionlint/releases/download/v1.0.0/actionlint_1.0.0_linux_386.tar.gz
 file="actionlint_${version}_${os}_${arch}.${ext}"
 url="https://github.com/rhysd/actionlint/releases/download/v${version}/${file}"
 
-echo "Downloading ${url} with curl"
+log "Downloading ${url} with curl"
 
 if [[ "$os" == "windows" ]]; then
     tempdir="$(mktemp -d actionlint.XXXXXXXXXXXXXXXX)"
@@ -149,9 +149,9 @@ else
     exe="$target_dir/actionlint"
 fi
 
-echo "Downloaded and unarchived executable: ${exe}"
+log "Downloaded and unarchived executable: ${exe}"
 
-echo "Done: $("${exe}" -version)"
+log "Done: $("${exe}" -version)"
 
 if [ -n "$GITHUB_ACTION" ]; then
     # On GitHub Actions, set executable path to output

--- a/scripts/download-actionlint.bash
+++ b/scripts/download-actionlint.bash
@@ -40,7 +40,7 @@ function usage() {
 log() {
     if [ "${GITHUB_ACTIONS}" ]
     then
-        echo "::notice::$@"
+        echo "::notice::$*"
     else
         echo "$@" 1>&2
     fi
@@ -49,14 +49,14 @@ log() {
 err() {
     if [ "${GITHUB_ACTIONS}" ]
     then
-        echo "::error::$@"
+        echo "::error::$*"
     else
         echo "$@" 1>&2
     fi
 }
 
 die() {
-    err "$@"
+    err "$*"
     exit 1
 }
 


### PR DESCRIPTION
This adds an `action.yml` file that downloads and installs the `actionlint` executable and runs it with options specified in the workflow file. Since the `scripts/download-actionlint.bash` file can get run in an action, the file also now uses the workflow commands to report errors/warnings etc... during the download.