### PR TITLE
Support disallowing specific runner labels

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,11 @@ type Config struct {
 		// Labels is label names for self-hosted runner.
 		Labels []string `yaml:"labels"`
 	} `yaml:"self-hosted-runner"`
+	// DisallowedLabels is configuration for disallowed runner labels.
+	DisallowedRunner struct {
+		// Labels is label names for runners.
+		Labels []string `yaml:"labels"`
+	} `yaml:"disallowed-runner"`
 	// ConfigVariables is names of configuration variables used in the checked workflows. When this value is nil,
 	// property names of `vars` context will not be checked. Otherwise actionlint will report a name which is not
 	// listed here as undefined config variables.

--- a/config_test.go
+++ b/config_test.go
@@ -40,6 +40,21 @@ func TestConfigParseOK(t *testing.T) {
 			input:  "self-hosted-runner:\n  labels: [foo, bar]",
 			labels: []string{"foo", "bar"},
 		},
+		{
+			what:   "null disallowed-runner labels",
+			input:  "disallowed-runner:\n  labels:",
+			labels: nil,
+		},
+		{
+			what:   "empty disallowed-runner labels",
+			input:  "disallowed-runner:\n  labels: []",
+			labels: []string{},
+		},
+		{
+			what:   "disallowed-runner labels",
+			input:  "disallowed-runner:\n  labels: [foo, bar]",
+			labels: []string{"foo", "bar"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -49,8 +64,13 @@ func TestConfigParseOK(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !cmp.Equal(c.SelfHostedRunner.Labels, tc.labels) {
-				t.Fatal(cmp.Diff(c.SelfHostedRunner.Labels, tc.labels))
+			if !cmp.Equal(c.SelfHostedRunner.Labels, tc.labels) && !cmp.Equal(c.DisallowedRunner.Labels, tc.labels) {
+				if !cmp.Equal(c.SelfHostedRunner.Labels, tc.labels) {
+					t.Fatal(cmp.Diff(c.SelfHostedRunner.Labels, tc.labels))
+				}
+				if !cmp.Equal(c.SelfHostedRunner.Labels, tc.labels) {
+					t.Fatal(cmp.Diff(c.SelfHostedRunner.Labels, tc.labels))
+				}
 			}
 		})
 	}

--- a/rule_runner_label.go
+++ b/rule_runner_label.go
@@ -170,6 +170,19 @@ func (rule *RuleRunnerLabel) verifyRunnerLabel(label *String) runnerOSCompat {
 		}
 	}
 
+	disallowed := rule.getDisallowedRunnerLabels()
+	for _, k := range disallowed {
+		if l == k {
+			rule.errorf(
+				label.Pos,
+				"label %q is not allowed. unavailable labels are %s",
+				label.Value,
+				quotesAll(disallowed),
+			)
+			return compatInvalid
+		}
+	}
+
 	rule.errorf(
 		label.Pos,
 		"label %q is unknown. available labels are %s. if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file",
@@ -285,4 +298,11 @@ func (rule *RuleRunnerLabel) getKnownLabels() []string {
 		return nil
 	}
 	return rule.config.SelfHostedRunner.Labels
+}
+
+func (rule *RuleRunnerLabel) getDisallowedRunnerLabels() []string {
+	if rule.config == nil {
+		return nil
+	}
+	return rule.config.DisallowedRunner.Labels
 }

--- a/rule_runner_label.go
+++ b/rule_runner_label.go
@@ -157,6 +157,19 @@ func (rule *RuleRunnerLabel) verifyRunnerLabel(label *String) runnerOSCompat {
 		return c
 	}
 
+	disallowed := rule.getDisallowedRunnerLabels()
+	for _, f := range disallowed {
+		if strings.EqualFold(l, f) {
+			rule.errorf(
+				label.Pos,
+				"label %q is not allowed. disallowed labels are %s",
+				label.Value,
+				quotesAll(disallowed),
+			)
+			return compatInvalid
+		}
+	}
+
 	for _, p := range selfHostedRunnerPresetOtherLabels {
 		if strings.EqualFold(l, p) {
 			return compatInvalid
@@ -166,19 +179,6 @@ func (rule *RuleRunnerLabel) verifyRunnerLabel(label *String) runnerOSCompat {
 	known := rule.getKnownLabels()
 	for _, k := range known {
 		if strings.EqualFold(l, k) {
-			return compatInvalid
-		}
-	}
-
-	disallowed := rule.getDisallowedRunnerLabels()
-	for _, k := range disallowed {
-		if l == k {
-			rule.errorf(
-				label.Pos,
-				"label %q is not allowed. unavailable labels are %s",
-				label.Value,
-				quotesAll(disallowed),
-			)
 			return compatInvalid
 		}
 	}

--- a/rule_runner_label_test.go
+++ b/rule_runner_label_test.go
@@ -7,11 +7,12 @@ import (
 
 func TestRuleRunnerLabelCheckLabels(t *testing.T) {
 	testCases := []struct {
-		what   string
-		labels []string
-		matrix []string
-		known  []string
-		errs   []string
+		what       string
+		labels     []string
+		matrix     []string
+		known      []string
+		disallowed []string
+		errs       []string
 	}{
 		// Normal cases
 		{
@@ -195,6 +196,12 @@ func TestRuleRunnerLabelCheckLabels(t *testing.T) {
 				`label "macos-latest" conflicts with label "windows-latest"`,
 			},
 		},
+		{
+			what:       "disallowed label",
+			disallowed: []string{"self-hosted"},
+			labels:     []string{"self-hosted"},
+			errs:       []string{`"self-hosted" is not allowed`},
+		},
 		// TODO: Add error tests for 'include:'
 	}
 
@@ -234,6 +241,7 @@ func TestRuleRunnerLabelCheckLabels(t *testing.T) {
 			rule := NewRuleRunnerLabel()
 			cfg := Config{}
 			cfg.SelfHostedRunner.Labels = tc.known
+			cfg.DisallowedRunner.Labels = tc.disallowed
 			rule.SetConfig(&cfg)
 			if err := rule.VisitJobPre(node); err != nil {
 				t.Fatal(err)

--- a/testdata/config/broken.yml
+++ b/testdata/config/broken.yml
@@ -1,1 +1,2 @@
 self-hosted-runner: 42
+disallowed-runner: 24

--- a/testdata/config/ok.yml
+++ b/testdata/config/ok.yml
@@ -2,3 +2,7 @@ self-hosted-runner:
   labels:
     - foo
     - bar
+disallowed-runner:
+  labels:
+    - foo
+    - bar

--- a/testdata/projects/user_defined_runner_label.out
+++ b/testdata/projects/user_defined_runner_label.out
@@ -1,1 +1,3 @@
 /workflows/test\.yaml:17:14: label "label3" is unknown\. .+\[runner-label\]/
+/workflows/test\.yaml:21:14: label "disallowed1" is not allowed\. .+\[runner-label\]/
+/workflows/test\.yaml:25:14: label "disallowed2" is not allowed\. .+\[runner-label\]/

--- a/testdata/projects/user_defined_runner_label/actionlint.yaml
+++ b/testdata/projects/user_defined_runner_label/actionlint.yaml
@@ -1,5 +1,5 @@
 self-hosted-runner:
   labels: ['label1', 'label2']
 disallowed-runner:
-  labels: ['label1', 'label2']
+  labels: ['disallowed1', 'disallowed2']
 config-variables: null

--- a/testdata/projects/user_defined_runner_label/actionlint.yaml
+++ b/testdata/projects/user_defined_runner_label/actionlint.yaml
@@ -1,3 +1,5 @@
 self-hosted-runner:
   labels: ['label1', 'label2']
+disallowed-runner:
+  labels: ['label1', 'label2']
 config-variables: null

--- a/testdata/projects/user_defined_runner_label/workflows/test.yaml
+++ b/testdata/projects/user_defined_runner_label/workflows/test.yaml
@@ -13,7 +13,15 @@ jobs:
     runs-on: label2
     steps:
       - run: echo
-  err:
+  err1:
     runs-on: label3
+    steps:
+      - run: echo
+  err2:
+    runs-on: "disallowed1"
+    steps:
+      - run: echo
+  err3:
+    runs-on: "disallowed2"
     steps:
       - run: echo


### PR DESCRIPTION
This extends the configuration options with a new `disallowed-runners` property containing `labels` that disallow certain `runs-on` labels. The disallowed labels can include known runner labels for scenarios where certain standard runners aren't desirable.

This is useful e.g. when migrating from one runner label to another in shared workflows to inform authors of changes made to workflows that certain labels are no longer allowed.

For example, this allows migrating away from e.g. `ubuntu-20.04` to `ubuntu-22.04` by configuring 

``` yaml
# File: actionlint.yaml

disallowed-runners: 
  labels: 
    - ubuntu-20.04
```

to mark the `ubuntu-20.04` label as not allowed.