### PR TITLE
Install actionlint in pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
 - id: actionlint
   name: Lint GitHub Actions workflow files
   description: Runs actionlint to lint GitHub Actions workflow files
-  language: system
+  language: golang
   types: ["yaml"]
   files: "^.github/workflows/"
   entry: actionlint


### PR DESCRIPTION
`pre-commit` can actually install all the necessary tools, if the proper language tag is configured.

This decouples the need to install `actionlint` separately.