### PR TITLE
Stronger external checks

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -504,7 +504,8 @@ func (l *Linter) check(
 			if err == nil {
 				rules = append(rules, r)
 			} else {
-				l.log("Rule \"shellcheck\" was disabled:", err)
+				l.log("Error in rule \"shellcheck\":", err)
+				return nil, err
 			}
 		} else {
 			l.log("Rule \"shellcheck\" was disabled since shellcheck command name was empty")
@@ -514,7 +515,8 @@ func (l *Linter) check(
 			if err == nil {
 				rules = append(rules, r)
 			} else {
-				l.log("Rule \"pyflakes\" was disabled:", err)
+				l.log("Error in rule \"pyflakes\":", err)
+				return nil, err
 			}
 		} else {
 			l.log("Rule \"pyflakes\" was disabled since pyflakes command name was empty")

--- a/linter_test.go
+++ b/linter_test.go
@@ -16,6 +16,102 @@ import (
 	"golang.org/x/sys/execabs"
 )
 
+func TestLinterShellcheckCommandNotFound(t *testing.T) {
+	dir := filepath.Join("testdata", "ok")
+
+	es, err := os.ReadDir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	fs := make([]string, 0, len(es))
+	for _, e := range es {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if strings.HasSuffix(n, ".yaml") || strings.HasSuffix(n, ".yml") {
+			fs = append(fs, filepath.Join(dir, n))
+		}
+	}
+
+	proj := &Project{root: dir}
+
+	shellcheck := "i_am_not_a_program"
+	pyflakes := ""
+
+	for _, f := range fs {
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			opts := LinterOptions{
+				Shellcheck: shellcheck,
+				Pyflakes:   pyflakes,
+			}
+
+			linter, err := NewLinter(io.Discard, &opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			config := Config{}
+			linter.defaultConfig = &config
+
+			errs, err := linter.LintFile(f, proj)
+			if err == nil {
+				t.Fatal("Non existing shellcheck command should fail")
+			}
+			_ = errs
+		})
+	}
+}
+
+func TestLinterPyflakesCommandNotFound(t *testing.T) {
+	dir := filepath.Join("testdata", "ok")
+
+	es, err := os.ReadDir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	fs := make([]string, 0, len(es))
+	for _, e := range es {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if strings.HasSuffix(n, ".yaml") || strings.HasSuffix(n, ".yml") {
+			fs = append(fs, filepath.Join(dir, n))
+		}
+	}
+
+	proj := &Project{root: dir}
+
+	shellcheck := ""
+	pyflakes := "i_am_not_a_program"
+
+	for _, f := range fs {
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			opts := LinterOptions{
+				Shellcheck: shellcheck,
+				Pyflakes:   pyflakes,
+			}
+
+			linter, err := NewLinter(io.Discard, &opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			config := Config{}
+			linter.defaultConfig = &config
+
+			errs, err := linter.LintFile(f, proj)
+			if err == nil {
+				t.Fatal("Non existing shellcheck command should fail")
+			}
+			_ = errs
+		})
+	}
+}
+
 func TestLinterLintOK(t *testing.T) {
 	dir := filepath.Join("testdata", "ok")
 


### PR DESCRIPTION
Hi, I have just started using `actionlint` and it is a great tool indeed.

I was just surprised that shell checks were disabled silently on my machine because the command was not found.

This pull request aims at solving this small unsafety. The consequence is that some invocations may fail and the user shall disable (or fix) shellcheck/pyflakes explicitly. Default values remain unchanged.

I added tests to check the new behaviour.