### PR TITLE
Remove `version` parameter in Winget workflow

### DIFF
--- a/.github/workflows/winget.yaml
+++ b/.github/workflows/winget.yaml
@@ -17,5 +17,4 @@ jobs:
           identifier: rhysd.actionlint
           installers-regex: '_windows_\w+\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
-          version: ${{ inputs.tag }}
           release-tag: ${{ inputs.tag }}


### PR DESCRIPTION
The `version` parameter is optional and derived from the `release-tag`, which usually cuts the `v` prefix from it. Otherwise, it would lead to an incorrect `PackageVersion` such as https://github.com/microsoft/winget-pkgs/pull/102052.