### PR TITLE
Change Winget job runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           git log -n 1
           git push
   winget:
-    runs-on: windows-latest # Action can only run on Windows
+    runs-on: ubuntu-latest
     needs: release
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2


### PR DESCRIPTION
Unrelated to the issue in #293, but Winget Releaser now supports non-Windows runners.