### PR TITLE
Changes to make actionlint usable when using it as a library

### DIFF
--- a/linter.go
+++ b/linter.go
@@ -342,7 +342,7 @@ func (l *Linter) LintFiles(filepaths []string, project *Project) ([]*Error, erro
 		})
 	}
 
-	proc.wait()
+	proc.Wait()
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (l *Linter) LintFile(path string, project *Project) ([]*Error, error) {
 	localActions := NewLocalActionsCache(project, dbg)
 	localReusableWorkflows := NewLocalReusableWorkflowCache(project, l.cwd, dbg)
 	errs, err := l.check(path, src, project, proc, localActions, localReusableWorkflows)
-	proc.wait()
+	proc.Wait()
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func (l *Linter) Lint(path string, content []byte, project *Project) ([]*Error, 
 	localActions := NewLocalActionsCache(project, dbg)
 	localReusableWorkflows := NewLocalReusableWorkflowCache(project, l.cwd, dbg)
 	errs, err := l.check(path, content, project, proc, localActions, localReusableWorkflows)
-	proc.wait()
+	proc.Wait()
 	if err != nil {
 		return nil, err
 	}

--- a/process.go
+++ b/process.go
@@ -78,7 +78,7 @@ func (proc *ConcurrentProcess) run(eg *errgroup.Group, exe string, args []string
 }
 
 // wait waits all goroutines started by this concurrentProcess instance finish.
-func (proc *ConcurrentProcess) wait() {
+func (proc *ConcurrentProcess) Wait() {
 	proc.wg.Wait() // Wait for all goroutines completing to shutdown
 }
 

--- a/process.go
+++ b/process.go
@@ -77,7 +77,7 @@ func (proc *ConcurrentProcess) run(eg *errgroup.Group, exe string, args []string
 	})
 }
 
-// wait waits all goroutines started by this concurrentProcess instance finish.
+// Wait waits all goroutines started by this concurrentProcess instance finish.
 func (proc *ConcurrentProcess) Wait() {
 	proc.wg.Wait() // Wait for all goroutines completing to shutdown
 }

--- a/process_test.go
+++ b/process_test.go
@@ -107,7 +107,7 @@ func TestProcessRunConcurrently(t *testing.T) {
 			return nil
 		})
 	}
-	if err := sleep.Wait(); err != nil {
+	if err := sleep.wait(); err != nil {
 		t.Fatal(err)
 	}
 	p.Wait()

--- a/process_test.go
+++ b/process_test.go
@@ -64,7 +64,7 @@ func TestProcessRunProcessSerial(t *testing.T) {
 	if err := echo.wait(); err != nil {
 		t.Fatal(err)
 	}
-	p.wait()
+	p.Wait()
 
 	if len(ret) != numProcs {
 		t.Fatalf("wanted %d outputs but got %#v", numProcs, ret)
@@ -107,10 +107,10 @@ func TestProcessRunConcurrently(t *testing.T) {
 			return nil
 		})
 	}
-	if err := sleep.wait(); err != nil {
+	if err := sleep.Wait(); err != nil {
 		t.Fatal(err)
 	}
-	p.wait()
+	p.Wait()
 
 	sec := time.Since(start).Seconds()
 	if sec >= 0.5 {
@@ -167,7 +167,7 @@ func TestProcessWaitMultipleCommandsFinish(t *testing.T) {
 		})
 	}
 
-	p.wait()
+	p.Wait()
 
 	for i, b := range done {
 		if !b {
@@ -193,7 +193,7 @@ func TestProcessInputStdin(t *testing.T) {
 	if err := cat.wait(); err != nil {
 		t.Fatal(err)
 	}
-	p.wait()
+	p.Wait()
 
 	if out != "this is test" {
 		t.Fatalf("stdin was not input to `cat` command: %q", out)
@@ -220,10 +220,10 @@ func TestProcessErrorCommandNotFound(t *testing.T) {
 
 	err := c.wait()
 	if err == nil || !strings.Contains(err.Error(), "yay! error found!") {
-		t.Fatalf("error was not reported by p.wait(): %v", err)
+		t.Fatalf("error was not reported by p.Wait(): %v", err)
 	}
 
-	p.wait()
+	p.Wait()
 
 	if !echoDone {
 		t.Fatal("a command following the error did not run")
@@ -247,10 +247,10 @@ func TestProcessErrorInCallback(t *testing.T) {
 
 	err := echo.wait()
 	if err == nil || err.Error() != "dummy error" {
-		t.Fatalf("error was not reported by p.wait(): %v", err)
+		t.Fatalf("error was not reported by p.Wait(): %v", err)
 	}
 
-	p.wait()
+	p.Wait()
 
 	if !echoDone {
 		t.Fatal("a command following the error did not run")
@@ -284,7 +284,7 @@ func TestProcessErrorLinterFailed(t *testing.T) {
 		t.Fatalf("Error message was unexpected: %q", msg)
 	}
 
-	p.wait()
+	p.Wait()
 
 	if !echoDone {
 		t.Fatal("a command following the error did not run")

--- a/rule.go
+++ b/rule.go
@@ -15,6 +15,13 @@ type RuleBase struct {
 	config *Config
 }
 
+func NewRuleBase(name string, desc string) *RuleBase {
+	return &RuleBase{
+		name: name,
+		desc: desc,
+	}
+}
+
 // VisitStep is callback when visiting Step node.
 func (r *RuleBase) VisitStep(node *Step) error { return nil }
 
@@ -30,12 +37,12 @@ func (r *RuleBase) VisitWorkflowPre(node *Workflow) error { return nil }
 // VisitWorkflowPost is callback when visiting Workflow node after visiting its children.
 func (r *RuleBase) VisitWorkflowPost(node *Workflow) error { return nil }
 
-func (r *RuleBase) error(pos *Pos, msg string) {
+func (r *RuleBase) Error(pos *Pos, msg string) {
 	err := errorAt(pos, r.name, msg)
 	r.errs = append(r.errs, err)
 }
 
-func (r *RuleBase) errorf(pos *Pos, format string, args ...interface{}) {
+func (r *RuleBase) Errorf(pos *Pos, format string, args ...interface{}) {
 	err := errorfAt(pos, r.name, format, args...)
 	r.errs = append(r.errs, err)
 }

--- a/rule_action.go
+++ b/rule_action.go
@@ -99,7 +99,7 @@ func (rule *RuleAction) checkRepoAction(spec string, exec *ExecAction) {
 }
 
 func (rule *RuleAction) invalidActionFormat(pos *Pos, spec string, why string) {
-	rule.errorf(pos, "specifying action %q in invalid format because %s. available formats are \"{owner}/{repo}@{ref}\" or \"{owner}/{repo}/{path}@{ref}\"", spec, why)
+	rule.Errorf(pos, "specifying action %q in invalid format because %s. available formats are \"{owner}/{repo}@{ref}\" or \"{owner}/{repo}/{path}@{ref}\"", spec, why)
 }
 
 // https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-the-github-packages-container-registry
@@ -116,7 +116,7 @@ func (rule *RuleAction) checkDockerAction(uri string, exec *ExecAction) {
 	}
 
 	if _, err := url.Parse(uri); err != nil {
-		rule.errorf(
+		rule.Errorf(
 			exec.Uses.Pos,
 			"URI for Docker container %q is invalid: %s (tag=%s)",
 			uri,
@@ -126,7 +126,7 @@ func (rule *RuleAction) checkDockerAction(uri string, exec *ExecAction) {
 	}
 
 	if tagExists && tag == "" {
-		rule.errorf(exec.Uses.Pos, "tag of Docker action should not be empty: %q", uri)
+		rule.Errorf(exec.Uses.Pos, "tag of Docker action should not be empty: %q", uri)
 	}
 }
 
@@ -134,7 +134,7 @@ func (rule *RuleAction) checkDockerAction(uri string, exec *ExecAction) {
 func (rule *RuleAction) checkLocalAction(path string, action *ExecAction) {
 	meta, err := rule.cache.FindMetadata(path)
 	if err != nil {
-		rule.error(action.Uses.Pos, err.Error())
+		rule.Error(action.Uses.Pos, err.Error())
 		return
 	}
 	if meta == nil {
@@ -154,7 +154,7 @@ func (rule *RuleAction) checkAction(meta *ActionMetadata, exec *ExecAction, desc
 			for _, i := range meta.Inputs {
 				ns = append(ns, i.Name)
 			}
-			rule.errorf(
+			rule.Errorf(
 				i.Name.Pos,
 				"input %q is not defined in action %s. available inputs are %s",
 				i.Name.Value,
@@ -174,7 +174,7 @@ func (rule *RuleAction) checkAction(meta *ActionMetadata, exec *ExecAction, desc
 						ns = append(ns, i.Name)
 					}
 				}
-				rule.errorf(
+				rule.Errorf(
 					exec.Uses.Pos,
 					"missing input %q which is required by action %s. all required inputs are %s",
 					i.Name,

--- a/rule_credentials.go
+++ b/rule_credentials.go
@@ -37,6 +37,6 @@ func (rule *RuleCredentials) checkContainer(where string, n *Container) {
 
 	p := n.Credentials.Password
 	if !p.IsExpressionAssigned() {
-		rule.errorf(p.Pos, "\"password\" section in %s should be specified via secrets. do not put password value directly", where)
+		rule.Errorf(p.Pos, "\"password\" section in %s should be specified via secrets. do not put password value directly", where)
 	}
 }

--- a/rule_deprecated_commands.go
+++ b/rule_deprecated_commands.go
@@ -46,7 +46,7 @@ func (rule *RuleDeprecatedCommands) VisitStep(n *Step) error {
 				panic("unreachable")
 			}
 
-			rule.errorf(
+			rule.Errorf(
 				r.Run.Pos,
 				"workflow command %q was deprecated. use `%s` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions",
 				c,

--- a/rule_env_var.go
+++ b/rule_env_var.go
@@ -50,7 +50,7 @@ func (rule *RuleEnvVar) checkEnv(env *Env) {
 			continue // Key name can contain expressions (#312)
 		}
 		if strings.ContainsAny(v.Name.Value, "&= 	") {
-			rule.errorf(
+			rule.Errorf(
 				v.Name.Pos,
 				"environment variable name %q is invalid. '&', '=' and spaces should not be contained",
 				v.Name.Value,

--- a/rule_glob.go
+++ b/rule_glob.go
@@ -65,6 +65,6 @@ func (rule *RuleGlob) globErrors(errs []InvalidGlobPattern, pos *Pos, quoted boo
 		if err.Column != 0 {
 			p.Col += err.Column - 1
 		}
-		rule.errorf(&p, "%s. note: filter pattern syntax is explained at https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet", err.Message)
+		rule.Errorf(&p, "%s. note: filter pattern syntax is explained at https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet", err.Message)
 	}
 }

--- a/rule_id.go
+++ b/rule_id.go
@@ -51,7 +51,7 @@ func (rule *RuleID) VisitStep(n *Step) error {
 
 	id := strings.ToLower(n.ID.Value)
 	if prev, ok := rule.seen[id]; ok {
-		rule.errorf(n.ID.Pos, "step ID %q duplicates. previously defined at %s. step ID must be unique within a job. note that step ID is case insensitive", n.ID.Value, prev.String())
+		rule.Errorf(n.ID.Pos, "step ID %q duplicates. previously defined at %s. step ID must be unique within a job. note that step ID is case insensitive", n.ID.Value, prev.String())
 		return nil
 	}
 	rule.seen[id] = n.ID.Pos
@@ -62,5 +62,5 @@ func (rule *RuleID) validateConvention(id *String, what string) {
 	if id == nil || id.Value == "" || id.ContainsExpression() || jobIDPattern.MatchString(id.Value) {
 		return
 	}
-	rule.errorf(id.Pos, "invalid %s ID %q. %s ID must start with a letter or _ and contain only alphanumeric characters, -, or _", what, id.Value, what)
+	rule.Errorf(id.Pos, "invalid %s ID %q. %s ID must start with a letter or _ and contain only alphanumeric characters, -, or _", what, id.Value, what)
 }

--- a/rule_if_cond.go
+++ b/rule_if_cond.go
@@ -42,7 +42,7 @@ func (rule *RuleIfCond) checkIfCond(n *String) {
 	if strings.HasPrefix(n.Value, "${{") && strings.HasSuffix(n.Value, "}}") && strings.Count(n.Value, "${{") == 1 {
 		return
 	}
-	rule.errorf(
+	rule.Errorf(
 		n.Pos,
 		"if: condition %q is always evaluated to true because extra characters are around ${{ }}",
 		n.Value,

--- a/rule_job_needs.go
+++ b/rule_job_needs.go
@@ -59,7 +59,7 @@ func (rule *RuleJobNeeds) VisitJobPre(n *Job) error {
 	for _, j := range n.Needs {
 		id := strings.ToLower(j.Value)
 		if contains(needs, id) {
-			rule.errorf(j.Pos, "job ID %q duplicates in \"needs\" section. note that job ID is case insensitive", j.Value)
+			rule.Errorf(j.Pos, "job ID %q duplicates in \"needs\" section. note that job ID is case insensitive", j.Value)
 			continue
 		}
 		if id != "" {
@@ -74,7 +74,7 @@ func (rule *RuleJobNeeds) VisitJobPre(n *Job) error {
 		return nil
 	}
 	if prev, ok := rule.nodes[id]; ok {
-		rule.errorf(n.Pos, "job ID %q duplicates. previously defined at %s. note that job ID is case insensitive", n.ID.Value, prev.pos.String())
+		rule.Errorf(n.Pos, "job ID %q duplicates. previously defined at %s. note that job ID is case insensitive", n.ID.Value, prev.pos.String())
 	}
 
 	rule.nodes[id] = &jobNode{
@@ -96,7 +96,7 @@ func (rule *RuleJobNeeds) VisitWorkflowPost(n *Workflow) error {
 		for _, dep := range node.needs {
 			n, ok := rule.nodes[dep]
 			if !ok {
-				rule.errorf(node.pos, "job %q needs job %q which does not exist in this workflow", id, dep)
+				rule.Errorf(node.pos, "job %q needs job %q which does not exist in this workflow", id, dep)
 				valid = false
 				continue
 			}
@@ -117,7 +117,7 @@ func (rule *RuleJobNeeds) VisitWorkflowPost(n *Workflow) error {
 			desc = append(desc, fmt.Sprintf("%q -> %q", from, to))
 		}
 
-		rule.errorf(
+		rule.Errorf(
 			edge.from.pos,
 			"cyclic dependencies in \"needs\" configurations of jobs are detected. detected cycle is %s",
 			strings.Join(desc, ", "),

--- a/rule_matrix.go
+++ b/rule_matrix.go
@@ -52,7 +52,7 @@ func (rule *RuleMatrix) checkDuplicateInRow(row *MatrixRow) {
 		ok := true
 		for _, p := range seen {
 			if p.Equals(v) {
-				rule.errorf(
+				rule.Errorf(
 					v.Pos(),
 					"duplicate value %s is found in matrix %q. the same value is at %s",
 					v.String(),
@@ -84,7 +84,7 @@ func (rule *RuleMatrix) checkExclude(m *Matrix) {
 	}
 
 	if len(m.Rows) == 0 && (m.Include == nil || len(m.Include.Combinations) == 0) {
-		rule.error(m.Pos, "\"exclude\" section exists but no matrix variation exists")
+		rule.Error(m.Pos, "\"exclude\" section exists but no matrix variation exists")
 		return
 	}
 
@@ -135,7 +135,7 @@ Outer:
 				for k := range vals {
 					ss = append(ss, k)
 				}
-				rule.errorf(
+				rule.Errorf(
 					a.Key.Pos,
 					"%q in \"exclude\" section does not exist in matrix. available matrix configurations are %s",
 					k,
@@ -152,7 +152,7 @@ Outer:
 			for _, v := range vs {
 				ss = append(ss, v.String())
 			}
-			rule.errorf(
+			rule.Errorf(
 				a.Value.Pos(),
 				"value %s in \"exclude\" does not exist in matrix %q combinations. possible values are %s",
 				a.Value.String(),

--- a/rule_permissions.go
+++ b/rule_permissions.go
@@ -54,7 +54,7 @@ func (rule *RulePermissions) checkPermissions(p *Permissions) {
 		case "write-all", "read-all":
 			// OK
 		default:
-			rule.errorf(p.All.Pos, "%q is invalid for permission for all the scopes. available values are \"read-all\" and \"write-all\"", p.All.Value)
+			rule.Errorf(p.All.Pos, "%q is invalid for permission for all the scopes. available values are \"read-all\" and \"write-all\"", p.All.Value)
 		}
 		return
 	}
@@ -66,13 +66,13 @@ func (rule *RulePermissions) checkPermissions(p *Permissions) {
 			for s := range allPermissionScopes {
 				ss = append(ss, s)
 			}
-			rule.errorf(p.Name.Pos, "unknown permission scope %q. all available permission scopes are %s", n, sortedQuotes(ss))
+			rule.Errorf(p.Name.Pos, "unknown permission scope %q. all available permission scopes are %s", n, sortedQuotes(ss))
 		}
 		switch p.Value.Value {
 		case "read", "write", "none":
 			// OK
 		default:
-			rule.errorf(p.Value.Pos, "%q is invalid for permission of scope %q. available values are \"read\", \"write\" or \"none\"", p.Value.Value, n)
+			rule.Errorf(p.Value.Pos, "%q is invalid for permission of scope %q. available values are \"read\", \"write\" or \"none\"", p.Value.Value, n)
 		}
 	}
 }

--- a/rule_pyflakes.go
+++ b/rule_pyflakes.go
@@ -153,7 +153,7 @@ func (rule *RulePyflakes) parseNextError(stdout []byte, pos *Pos) ([]byte, error
 	} else {
 		return nil, fmt.Errorf("error message from pyflakes does not end with \\n nor \\r\\n while checking script at %s. output: %q", pos, stdout)
 	}
-	rule.errorf(pos, "pyflakes reported issue in this script: %s", msg)
+	rule.Errorf(pos, "pyflakes reported issue in this script: %s", msg)
 
 	return b, nil
 }

--- a/rule_runner_label.go
+++ b/rule_runner_label.go
@@ -186,7 +186,7 @@ func (rule *RuleRunnerLabel) verifyRunnerLabel(label *String) runnerOSCompat {
 		}
 	}
 
-	rule.errorf(
+	rule.Errorf(
 		label.Pos,
 		"label %q is unknown. available labels are %s. if it is a custom label for self-hosted runner, set list of labels in actionlint.yaml config file",
 		label.Value,
@@ -261,7 +261,7 @@ func (rule *RuleRunnerLabel) tryToGetLabelsInMatrix(label *String, m *Matrix) []
 func (rule *RuleRunnerLabel) checkConflict(comp runnerOSCompat, label *String) bool {
 	for c, l := range rule.compats {
 		if c&comp == 0 {
-			rule.errorf(label.Pos, "label %q conflicts with label %q defined at %s. note: to run your job on each workers, use matrix", label.Value, l.Value, l.Pos)
+			rule.Errorf(label.Pos, "label %q conflicts with label %q defined at %s. note: to run your job on each workers, use matrix", label.Value, l.Value, l.Pos)
 			return false
 		}
 	}

--- a/rule_shell_name.go
+++ b/rule_shell_name.go
@@ -105,7 +105,7 @@ func (rule *RuleShellName) checkShellName(node *String) {
 		}
 	}
 
-	rule.errorf(
+	rule.Errorf(
 		node.Pos,
 		"shell name %q is invalid%s. available names are %s",
 		node.Value,

--- a/rule_shellcheck.go
+++ b/rule_shellcheck.go
@@ -209,7 +209,7 @@ func (rule *RuleShellcheck) runShellcheck(src, sh string, pos *Pos) {
 			// Consider the first line is setup for running shell which was implicitly added for better check
 			line := err.Line - 1
 			msg := strings.TrimSuffix(err.Message, ".") // Trim period aligning style of error message
-			rule.errorf(pos, "shellcheck reported issue in this script: SC%d:%s:%d:%d: %s", err.Code, err.Level, line, err.Column, msg)
+			rule.Errorf(pos, "shellcheck reported issue in this script: SC%d:%s:%d:%d: %s", err.Code, err.Level, line, err.Column, msg)
 		}
 
 		return nil

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -68,7 +68,7 @@ func (rule *RuleWorkflowCall) VisitJobPre(n *Job) error {
 		rule.cache.writeCache(u.Value, nil)
 	}
 
-	rule.errorf(
+	rule.Errorf(
 		u.Pos,
 		"reusable workflow call %q at \"uses\" is not following the format \"owner/repo/path/to/workflow.yml@ref\" nor \"./path/to/workflow.yml\". see https://docs.github.com/en/actions/learn-github-actions/reusing-workflows for more details",
 		u.Value,
@@ -80,7 +80,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 	u := call.Uses
 	m, err := rule.cache.FindMetadata(u.Value)
 	if err != nil {
-		rule.error(u.Pos, err.Error())
+		rule.Error(u.Pos, err.Error())
 		return
 	}
 	if m == nil {
@@ -92,7 +92,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 	for n, i := range m.Inputs {
 		if i != nil && i.Required {
 			if _, ok := call.Inputs[n]; !ok {
-				rule.errorf(u.Pos, "input %q is required by %q reusable workflow", i.Name, u.Value)
+				rule.Errorf(u.Pos, "input %q is required by %q reusable workflow", i.Name, u.Value)
 			}
 		}
 	}
@@ -110,7 +110,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 					note = "defined inputs are " + sortedQuotes(is)
 				}
 			}
-			rule.errorf(i.Name.Pos, "input %q is not defined in %q reusable workflow. %s", i.Name.Value, u.Value, note)
+			rule.Errorf(i.Name.Pos, "input %q is not defined in %q reusable workflow. %s", i.Name.Value, u.Value, note)
 		}
 	}
 
@@ -119,7 +119,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 		for n, s := range m.Secrets {
 			if s.Required {
 				if _, ok := call.Secrets[n]; !ok {
-					rule.errorf(u.Pos, "secret %q is required by %q reusable workflow", s.Name, u.Value)
+					rule.Errorf(u.Pos, "secret %q is required by %q reusable workflow", s.Name, u.Value)
 				}
 			}
 		}
@@ -137,7 +137,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 						note = "defined secrets are " + sortedQuotes(ss)
 					}
 				}
-				rule.errorf(s.Name.Pos, "secret %q is not defined in %q reusable workflow. %s", s.Name.Value, u.Value, note)
+				rule.Errorf(s.Name.Pos, "secret %q is not defined in %q reusable workflow. %s", s.Name.Value, u.Value, note)
 			}
 		}
 	}


### PR DESCRIPTION
I've added a constructor for _RuleBase_ and changed _error_ and _errorf_ from private to public, otherwise It's not possible to create new rules. I hope that this is the best option, if not, how should we create new rules when using _actionlint_ as a library ? 

I also changed _wait_ from private to public in _process.go_.