### PR TITLE
Change Debug to public and add new script injection input

### DIFF
--- a/expr_insecure.go
+++ b/expr_insecure.go
@@ -24,6 +24,9 @@ func (m *UntrustedInputMap) findObjectProp(name string) (*UntrustedInputMap, boo
 		if c, ok := m.Children[name]; ok {
 			return c, true
 		}
+		if c, ok := m.Children["*"]; ok {
+			return c, true
+		}
 	}
 	return nil, false
 }
@@ -132,6 +135,9 @@ var BuiltinUntrustedInputs = UntrustedInputSearchRoots{
 			),
 		),
 		NewUntrustedInputMap("head_ref"),
+	),
+	"env": NewUntrustedInputMap("env",
+		NewUntrustedInputMap("*"),
 	),
 }
 

--- a/rule.go
+++ b/rule.go
@@ -53,7 +53,7 @@ func (r *RuleBase) Errorf(pos *Pos, format string, args ...interface{}) {
 	r.errs = append(r.errs, err)
 }
 
-func (r *RuleBase) debug(format string, args ...interface{}) {
+func (r *RuleBase) Debug(format string, args ...interface{}) {
 	if r.dbg == nil {
 		return
 	}

--- a/rule_action.go
+++ b/rule_action.go
@@ -85,11 +85,11 @@ func (rule *RuleAction) checkRepoAction(spec string, exec *ExecAction) {
 
 	meta, ok := PopularActions[spec]
 	if !ok {
-		rule.debug("This action is not found in popular actions data set: %s", spec)
+		rule.Debug("This action is not found in popular actions data set: %s", spec)
 		return
 	}
 	if meta.SkipInputs {
-		rule.debug("This action skips to check inputs: %s", spec)
+		rule.Debug("This action skips to check inputs: %s", spec)
 		return
 	}
 

--- a/rule_expression.go
+++ b/rule_expression.go
@@ -778,7 +778,7 @@ func (rule *RuleExpression) checkSemanticsOfExprNode(expr ExprNode, line, col in
 	if workflowKey != "" {
 		ctx, sp := WorkflowKeyAvailability(workflowKey)
 		if len(ctx) == 0 {
-			rule.debug("No context avaiability was found for workflow key %q", workflowKey)
+			rule.Debug("No context avaiability was found for workflow key %q", workflowKey)
 		}
 		c.SetContextAvailability(ctx)
 		c.SetSpecialFunctionAvailability(sp)

--- a/rule_pyflakes.go
+++ b/rule_pyflakes.go
@@ -153,7 +153,7 @@ func (rule *RulePyflakes) parseNextError(stdout []byte, pos *Pos) ([]byte, error
 	} else {
 		return nil, fmt.Errorf("error message from pyflakes does not end with \\n nor \\r\\n while checking script at %s. output: %q", pos, stdout)
 	}
-	rule.errorf(pos, "pyflakes reported issue in this script: %s", msg)
+	rule.Errorf(pos, "pyflakes reported issue in this script: %s", msg)
 
 	return b, nil
 }

--- a/rule_pyflakes.go
+++ b/rule_pyflakes.go
@@ -111,11 +111,11 @@ func (rule *RulePyflakes) isPythonShell(r *ExecRun) bool {
 
 func (rule *RulePyflakes) runPyflakes(src string, pos *Pos) {
 	src = sanitizeExpressionsInScript(src) // Defined at rule_shellcheck.go
-	rule.debug("%s: Running %s for Python script:\n%s", pos, rule.cmd.exe, src)
+	rule.Debug("%s: Running %s for Python script:\n%s", pos, rule.cmd.exe, src)
 
 	rule.cmd.run([]string{}, src, func(stdout []byte, err error) error {
 		if err != nil {
-			rule.debug("Command %s failed: %v", rule.cmd.exe, err)
+			rule.Debug("Command %s failed: %v", rule.cmd.exe, err)
 			return fmt.Errorf("`%s` did not run successfully while checking script at %s: %w", rule.cmd.exe, pos, err)
 		}
 		if len(stdout) == 0 {
@@ -153,7 +153,7 @@ func (rule *RulePyflakes) parseNextError(stdout []byte, pos *Pos) ([]byte, error
 	} else {
 		return nil, fmt.Errorf("error message from pyflakes does not end with \\n nor \\r\\n while checking script at %s. output: %q", pos, stdout)
 	}
-	rule.Errorf(pos, "pyflakes reported issue in this script: %s", msg)
+	rule.errorf(pos, "pyflakes reported issue in this script: %s", msg)
 
 	return b, nil
 }

--- a/rule_shellcheck.go
+++ b/rule_shellcheck.go
@@ -158,7 +158,7 @@ func sanitizeExpressionsInScript(src string) string {
 
 func (rule *RuleShellcheck) runShellcheck(src, sh string, pos *Pos) {
 	src = sanitizeExpressionsInScript(src)
-	rule.debug("%s: Run shellcheck for %s script:\n%s", pos, sh, src)
+	rule.Debug("%s: Run shellcheck for %s script:\n%s", pos, sh, src)
 
 	// Reasons to exclude the rules:
 	//
@@ -173,7 +173,7 @@ func (rule *RuleShellcheck) runShellcheck(src, sh string, pos *Pos) {
 	// - SC2157: Argument to -z is always false due to literal strings. When the argument of -z is replaced from ${{ }},
 	//           this can happen. For example, `if [ -z ${{ env.FOO }} ]` -> `if [ -z ______________ ]` (#113).
 	args := []string{"--norc", "-f", "json", "-x", "--shell", sh, "-e", "SC1091,SC2194,SC2050,SC2154,SC2157", "-"}
-	rule.debug("%s: Running %s command with %s", pos, rule.cmd.exe, args)
+	rule.Debug("%s: Running %s command with %s", pos, rule.cmd.exe, args)
 
 	// Use same options to run shell process described at document
 	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
@@ -185,7 +185,7 @@ func (rule *RuleShellcheck) runShellcheck(src, sh string, pos *Pos) {
 
 	rule.cmd.run(args, script, func(stdout []byte, err error) error {
 		if err != nil {
-			rule.debug("Command %s %s failed: %v", rule.cmd.exe, args, err)
+			rule.Debug("Command %s %s failed: %v", rule.cmd.exe, args, err)
 			return fmt.Errorf("`%s %s` did not run successfully while checking script at %s: %w", rule.cmd.exe, strings.Join(args, " "), pos, err)
 		}
 

--- a/rule_workflow_call.go
+++ b/rule_workflow_call.go
@@ -84,7 +84,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 		return
 	}
 	if m == nil {
-		rule.debug("Skip workflow call %q since no metadata was found", u.Value)
+		rule.Debug("Skip workflow call %q since no metadata was found", u.Value)
 		return
 	}
 
@@ -142,7 +142,7 @@ func (rule *RuleWorkflowCall) checkWorkflowCallUsesLocal(call *WorkflowCall) {
 		}
 	}
 
-	rule.debug("Validated reusable workflow %q", u.Value)
+	rule.Debug("Validated reusable workflow %q", u.Value)
 }
 
 // Parse ./{path/{filename}


### PR DESCRIPTION
I've changed the _Debug_ method of _RuleBase_ since we can now add new rules.

And I've also added a new entry in _BuiltinUntrustedInputs_ because I already saw something like this where It's possible to inject code in the runner from an opened issue:

```yaml
name: Test

on:
  issues:
    types: [opened]

jobs:
  dummyjob:
    runs-on: ubuntu-latest
    steps:
      - name: parse issue Body
        id: prepareBody
        shell: pwsh
        run: |
          # this script parse issue and set env variables
          .\scripts\issue-body-parser.ps1 $env:BODY
        env:
          BODY: ${{ github.event.issue.body }}
      
      - name: Injection step
        shell: pwsh
        run: |
          
          # InjectionEntry comes from issue-body-parser.ps1 
          # which parse the body and do something like this
          # Write-Output "InjectionEntry=$dataparsedFromIssue" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append

          .\scripts\my-script.ps1 -param ${{ env.InjectionEntry}}
        
```


```
./main env-inject.yml       
env-inject.yml :22:265: "env.*" is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable. see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions for more details [expression]
```