### PR TITLE
fix: fix activity types of the event `watch`

### DIFF
--- a/all_webhooks.go
+++ b/all_webhooks.go
@@ -36,7 +36,7 @@ var AllWebhookTypes = map[string][]string{
 	"release":                     {"published", "unpublished", "created", "edited", "deleted", "prereleased", "released"},
 	"repository_dispatch":         {},
 	"status":                      {},
-	"watch":                       {"starred"},
+	"watch":                       {"started"},
 	"workflow_dispatch":           {},
 	"workflow_run":                {"completed", "requested", "in_progress"},
 }


### PR DESCRIPTION
The activity type `starred` is wrong.
The correct activity type is `started`.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#watch

GitHub's official document was wrong, so I fixed it.

- https://github.com/github/docs/pull/27127
- https://github.com/github/docs/issues/27129