### PR TITLE
Add usage instructions for Emacs

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -384,6 +384,12 @@ As alternatives to `actionlint` hook, `actionlint-docker` or `actionlint-system`
 [Linter extension][vsc-extension] for [VS Code][vscode] is available. The extension automatically detects `.github/workflows`
 directory, runs `actionlint` command, and reports errors in the code editor while editing workflow files.
 
+### Emacs
+
+Plugins for both [Flycheck][emacs-flycheck] and [Flymake][emacs-flymake] are available via [MELPA][emacs-melpa].
+
+Their respective repositories are [flycheck-actionlint][emacs-flycheck-extension] and [flymake-actionlint][emacs-flymake-extension].
+
 ### Nova
 
 [Nova.app][nova] is a MacOS only editor and IDE. The [Actionlint for Nova][nova-extension] allows you to get inline feedback
@@ -449,6 +455,11 @@ You can also see actionlint issues inline in VS Code via the [Trunk VS Code exte
 [docker-image]: https://hub.docker.com/r/rhysd/actionlint
 [vsc-extension]: https://marketplace.visualstudio.com/items?itemName=arahata.linter-actionlint
 [vscode]: https://code.visualstudio.com/
+[emacs-melpa]: https://melpa.org/
+[emacs-flymake]: https://www.gnu.org/software/emacs/manual/html_node/flymake/
+[emacs-flymake-extension]: https://github.com/ROCKTAKEY/flymake-actionlint
+[emacs-flycheck]: https://www.flycheck.org/
+[emacs-flycheck-extension]: https://github.com/tirimia/flycheck-actionlint
 [nova-extension]: https://extensions.panic.com/extensions/org.netwrk/org.netwrk.actionlint/
 [nova]: https://nova.app
 [trunk-io]: https://docs.trunk.io/docs


### PR DESCRIPTION
Howdy!

I have recently published a package to integrate this amazing linter into an Emacs diagnostic provider and @ROCKTAKEY has done the same for the builtin mechanism.

To increase the visibility of these packages and help your users integrate actionlint into their workflows easier, I updated the usage docs.

Please let me know if I should change anything, and thank you for contributing such an awesome piece of software to the community, it's been a life-saver 😸 