### PR TITLE
Set explicit version in precommit snippet

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -366,7 +366,7 @@ Add this to your `.pre-commit-config.yaml` in your repository:
 ---
 repos:
   - repo: https://github.com/rhysd/actionlint
-    rev: main
+    rev: v1.6.26
     hooks:
       - id: actionlint
 ```


### PR DESCRIPTION
When using `rev: main`, pre-commit throws the following warning:
```log
pre-commit run --all-files               
[WARNING] The 'rev' field of repo 'https://github.com/rhysd/actionlint' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
```

From https://pre-commit.com/#using-the-latest-version-for-a-repository:
>Using the latest version for a repository ¶
pre-commit configuration aims to give a repeatable and fast experience and therefore intentionally doesn't provide facilities for "unpinned latest version" for hook repositories.
>
>Instead, pre-commit provides tools to make it easy to upgrade to the latest versions with pre-commit autoupdate. If you need the absolute latest version of a hook (instead of the latest tagged version), pass the --bleeding-edge parameter to autoupdate.
>
>pre-commit assumes that the value of rev is an immutable ref (such as a tag or SHA) and will cache based on that. Using a branch name (or HEAD) for the value of rev is not supported and will only represent the state of that mutable ref at the time of hook installation (and will NOT update automatically).