### PR TITLE
Add several google-github-actions etc to generate-popular-actions list

### DIFF
--- a/scripts/generate-popular-actions/main.go
+++ b/scripts/generate-popular-actions/main.go
@@ -341,6 +341,26 @@ var popularActions = []*action{
 		next: "v4",
 	},
 	{
+		slug: "google-github-actions/auth",
+		tags: []string{"v0", "v1"},
+		next: "v2",
+	},
+	{
+		slug: "google-github-actions/get-secretmanager-secrets",
+		tags: []string{"v0", "v1"},
+		next: "v2",
+	},
+	{
+		slug: "google-github-actions/setup-gcloud",
+		tags: []string{"v0", "v1"},
+		next: "v2",
+	},
+	{
+		slug: "google-github-actions/upload-cloud-storage",
+		tags: []string{"v0", "v1"},
+		next: "v2",
+	},
+	{
 		slug: "goreleaser/goreleaser-action",
 		tags: []string{"v1", "v2", "v3", "v4", "v5"},
 		next: "v6",
@@ -405,6 +425,16 @@ var popularActions = []*action{
 		slug: "preactjs/compressed-size-action",
 		tags: []string{"v1", "v2"},
 		next: "v3",
+	},
+	{
+		slug: "pulumi/actions",
+		tags: []string{"v1", "v2", "v3", "v4"},
+		next: "v5",
+	},
+	{
+		slug: "pypa/gh-action-pypi-publish",
+		tags: []string{"release/v1"},
+		next: "release/v2",
 	},
 	{
 		slug: "reviewdog/action-actionlint",


### PR DESCRIPTION
For your consideration, this adds several probably commonly used actions to the list of known actions.

In particular, it was common to use `service_account_key` with google-github-actions/setup-gcloud@v0 to do simple token-via-a-secret authentication. However google-github-actions/setup-gcloud@v1 ignores this option and wants that style of authentication to be expressed in a different way. So for people updating workflows that use setup-gcloud, it's very useful for actionlint to detect the error that will result from just applying `s/@v0/@v1/`.

We use setup-gcloud and auth ourselves; the four I've added here are the most fundamental-looking of the google-github-actions organisation's pinned actions repositories.

I've taken the liberty of also adding pypa/gh-action-pypi-publish as it is important in the Python ecosystem, and pulumi/actions for those using this deployment tool. Those could certainly be dropped from this PR if you didn't want to bloat the popular list with them.