### PR TITLE
pre-commit: include fully qualified container name

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
   language: docker_image
   types: ["yaml"]
   files: ^\.github/workflows/
-  entry: rhysd/actionlint:1.6.26
+  entry: docker.io/rhysd/actionlint:1.6.26
 - id: actionlint-system
   name: Lint GitHub Actions workflow files
   description: Runs system-installed actionlint to lint GitHub Actions workflow files

--- a/scripts/bump-version.bash
+++ b/scripts/bump-version.bash
@@ -40,10 +40,10 @@ echo "Bumping up version to ${version} (tag: ${tag})"
 # Update container image tag in pre-commit hook (See #116 for more details)
 case "$OSTYPE" in
     darwin*)
-        /usr/bin/sed -i '' -E "s/entry: rhysd\\/actionlint:.*/entry: rhysd\\/actionlint:${version}/" "$pre_commit_hook"
+        /usr/bin/sed -i '' -E "s/entry: docker.io\\/rhysd\\/actionlint:.*/entry: docker.io\\/rhysd\\/actionlint:${version}/" "$pre_commit_hook"
         ;;
     *)
-        sed -i -E "s/entry: rhysd\\/actionlint:.*/entry: rhysd\\/actionlint:${version}/" "$pre_commit_hook"
+        sed -i -E "s/entry: docker.io\\/rhysd\\/actionlint:.*/entry: docker.io\\/rhysd\\/actionlint:${version}/" "$pre_commit_hook"
         ;;
 esac
 


### PR DESCRIPTION
Alternative container engines such as podman don't default to Docker Hub and require specifying the fully qualified container url.