### PR TITLE
make ContainsExpression(s string) public

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -42,14 +42,14 @@ type String struct {
 	Pos *Pos
 }
 
-func containsExpression(s string) bool {
+func ContainsExpression(s string) bool {
 	i := strings.Index(s, "${{")
 	return i >= 0 && i < strings.Index(s, "}}")
 }
 
 // ContainsExpression returns whether the string contains at least one ${{ }} expression.
 func (s *String) ContainsExpression() bool {
-	return containsExpression(s.Value)
+	return ContainsExpression(s.Value)
 }
 
 func isExprAssigned(s string) bool {

--- a/reusable_workflow.go
+++ b/reusable_workflow.go
@@ -205,7 +205,7 @@ func (c *LocalReusableWorkflowCache) writeCache(key string, val *ReusableWorkflo
 //
 // Calling this method is thread-safe.
 func (c *LocalReusableWorkflowCache) FindMetadata(spec string) (*ReusableWorkflowMetadata, error) {
-	if c.proj == nil || !strings.HasPrefix(spec, "./") || containsExpression(spec) {
+	if c.proj == nil || !strings.HasPrefix(spec, "./") || ContainsExpression(spec) {
 		return nil, nil
 	}
 

--- a/rule_runner_label.go
+++ b/rule_runner_label.go
@@ -247,7 +247,7 @@ func (rule *RuleRunnerLabel) tryToGetLabelsInMatrix(label *String, m *Matrix) []
 	if m.Rows != nil {
 		if row, ok := m.Rows[prop]; ok {
 			for _, v := range row.Values {
-				if s, ok := v.(*RawYAMLString); ok && !containsExpression(s.Value) {
+				if s, ok := v.(*RawYAMLString); ok && !ContainsExpression(s.Value) {
 					labels = append(labels, &String{s.Value, false, s.Pos()})
 				}
 			}
@@ -258,7 +258,7 @@ func (rule *RuleRunnerLabel) tryToGetLabelsInMatrix(label *String, m *Matrix) []
 		for _, combi := range m.Include.Combinations {
 			if combi.Assigns != nil {
 				if assign, ok := combi.Assigns[prop]; ok {
-					if s, ok := assign.Value.(*RawYAMLString); ok && !containsExpression(s.Value) {
+					if s, ok := assign.Value.(*RawYAMLString); ok && !ContainsExpression(s.Value) {
 						labels = append(labels, &String{s.Value, false, s.Pos()})
 					}
 				}


### PR DESCRIPTION
Make `ContainsExpression(s string) `public as `(s *String) ContainsExpression() ` is already public. This can be usefull when using actionlint as a library.