### PR TITLE
Remove --norc flag from shellcheck command args

### DIFF
--- a/rule_shellcheck.go
+++ b/rule_shellcheck.go
@@ -172,7 +172,7 @@ func (rule *RuleShellcheck) runShellcheck(src, sh string, pos *Pos) {
 	//           so this rule can cause false positives (#53).
 	// - SC2157: Argument to -z is always false due to literal strings. When the argument of -z is replaced from ${{ }},
 	//           this can happen. For example, `if [ -z ${{ env.FOO }} ]` -> `if [ -z ______________ ]` (#113).
-	args := []string{"--norc", "-f", "json", "-x", "--shell", sh, "-e", "SC1091,SC2194,SC2050,SC2154,SC2157", "-"}
+	args := []string{"-f", "json", "-x", "--shell", sh, "-e", "SC1091,SC2194,SC2050,SC2154,SC2157", "-"}
 	rule.Debug("%s: Running %s command with %s", pos, rule.cmd.exe, args)
 
 	// Use same options to run shell process described at document


### PR DESCRIPTION
This should allow for shellcheck to load custom configuration if exist in project root.

fixes #395 