### PR TITLE
Update `checkout` action version in documentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -207,7 +207,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -246,7 +246,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check workflow files
         uses: docker://rhysd/actionlint:latest
         with:
@@ -321,7 +321,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1
 ```
 

--- a/man/actionlint.1.ronn
+++ b/man/actionlint.1.ronn
@@ -160,7 +160,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)


### PR DESCRIPTION
`actions/checkout@v3` produces a warning about deprecated Node.js version ([see also](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)).
