### PR TITLE
preactjs/compressed-size-action@v2 is new

### DIFF
--- a/popular_actions.go
+++ b/popular_actions.go
@@ -3770,7 +3770,6 @@ var OutdatedPopularActionSpecs = map[string]struct{}{
 	"peter-evans/create-pull-request@v2":               {},
 	"peter-evans/create-pull-request@v3":               {},
 	"preactjs/compressed-size-action@v1":               {},
-	"preactjs/compressed-size-action@v2":               {},
 	"pulumi/actions@v2":                                {},
 	"pulumi/actions@v3":                                {},
 	"ridedott/merge-me-action@v1":                      {},


### PR DESCRIPTION
preactjs/compressed-size-action@v2 was old to points 2.5.0. Now it's new to points 2.6.0.

https://github.com/preactjs/compressed-size-action/tags

v2 (2.6.0) uses node20 runtime.

https://github.com/preactjs/compressed-size-action/blob/v2/action.yml#L46