### PR TITLE
Skip PR creation in the generate workflow in forks

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -47,4 +47,4 @@ jobs:
             This PR was created by [this workflow run](https://github.com/rhysd/actionlint/actions/runs/${{ github.run_id }}) automatically.
             List of workflow runs is [here](https://github.com/rhysd/actionlint/actions/workflows/generate.yaml).
           assignees: rhysd
-        if: ${{ steps.diff.outputs.pr == 'true' }}
+        if: ${{ steps.diff.outputs.pr == 'true' && github.repository == 'rhysd/actionlint' }}


### PR DESCRIPTION
As it's unnecessary (as the needed PR will be opened by workflow runs in this, the original "upstream" repository) and only causes noise in forks. See for example [this run](https://github.com/muzimuzhi/actionlint/actions/runs/11305433070/job/31444920812#annotation:7:100) in my fork.