### PR TITLE
Fix false-positive script injection warnings when using builtin functions with stable outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /playground-dist
 /actionlint-workflow-ast
 /.git-hooks/.timestamp
+/.idea

--- a/expr_ast.go
+++ b/expr_ast.go
@@ -5,6 +5,8 @@ package actionlint
 type ExprNode interface {
 	// Token returns the first token of the node. This method is useful to get position of this node.
 	Token() *Token
+	// Parent returns the parent node of this node.
+	Parent() ExprNode
 }
 
 // Variable
@@ -12,8 +14,9 @@ type ExprNode interface {
 // VariableNode is node for variable access.
 type VariableNode struct {
 	// Name is name of the variable
-	Name string
-	tok  *Token
+	Name   string
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
@@ -21,11 +24,17 @@ func (n *VariableNode) Token() *Token {
 	return n.tok
 }
 
+// Parent returns the parent node of this node.
+func (n *VariableNode) Parent() ExprNode {
+	return n.parent
+}
+
 // Literals
 
 // NullNode is node for null literal.
 type NullNode struct {
-	tok *Token
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
@@ -33,11 +42,17 @@ func (n *NullNode) Token() *Token {
 	return n.tok
 }
 
+// Parent returns the parent node of this node.
+func (n *NullNode) Parent() ExprNode {
+	return n.parent
+}
+
 // BoolNode is node for boolean literal, true or false.
 type BoolNode struct {
 	// Value is value of the boolean literal.
-	Value bool
-	tok   *Token
+	Value  bool
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
@@ -45,11 +60,17 @@ func (n *BoolNode) Token() *Token {
 	return n.tok
 }
 
+// Parent returns the parent node of this node.
+func (n *BoolNode) Parent() ExprNode {
+	return n.parent
+}
+
 // IntNode is node for integer literal.
 type IntNode struct {
 	// Value is value of the integer literal.
-	Value int
-	tok   *Token
+	Value  int
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
@@ -57,11 +78,17 @@ func (n *IntNode) Token() *Token {
 	return n.tok
 }
 
+// Parent returns the parent node of this node.
+func (n *IntNode) Parent() ExprNode {
+	return n.parent
+}
+
 // FloatNode is node for float literal.
 type FloatNode struct {
 	// Value is value of the float literal.
-	Value float64
-	tok   *Token
+	Value  float64
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
@@ -69,17 +96,28 @@ func (n *FloatNode) Token() *Token {
 	return n.tok
 }
 
+// Parent returns the parent node of this node.
+func (n *FloatNode) Parent() ExprNode {
+	return n.parent
+}
+
 // StringNode is node for string literal.
 type StringNode struct {
 	// Value is value of the string literal. Escapes are resolved and quotes at both edges are
 	// removed.
-	Value string
-	tok   *Token
+	Value  string
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
 func (n *StringNode) Token() *Token {
 	return n.tok
+}
+
+// Parent returns the parent node of this node.
+func (n *StringNode) Parent() ExprNode {
+	return n.parent
 }
 
 // Operators
@@ -90,22 +128,34 @@ type ObjectDerefNode struct {
 	Receiver ExprNode
 	// Property is a name of property to access.
 	Property string
+	parent   ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
-func (n ObjectDerefNode) Token() *Token {
+func (n *ObjectDerefNode) Token() *Token {
 	return n.Receiver.Token()
+}
+
+// Parent returns the parent node of this node.
+func (n *ObjectDerefNode) Parent() ExprNode {
+	return n.parent
 }
 
 // ArrayDerefNode represents elements dereference of arrays like '*' in 'foo.bar.*.piyo'.
 type ArrayDerefNode struct {
 	// Receiver is an expression at receiver of array element dereference.
 	Receiver ExprNode
+	parent   ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
-func (n ArrayDerefNode) Token() *Token {
+func (n *ArrayDerefNode) Token() *Token {
 	return n.Receiver.Token()
+}
+
+// Parent returns the parent node of this node.
+func (n *ArrayDerefNode) Parent() ExprNode {
+	return n.parent
 }
 
 // IndexAccessNode is node for index access, which represents dynamic object property access or
@@ -114,12 +164,18 @@ type IndexAccessNode struct {
 	// Operand is an expression at operand of index access, which should be array or object.
 	Operand ExprNode
 	// Index is an expression at index, which should be integer or string.
-	Index ExprNode
+	Index  ExprNode
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
 func (n *IndexAccessNode) Token() *Token {
 	return n.Operand.Token()
+}
+
+// Parent returns the parent node of this node.
+func (n *IndexAccessNode) Parent() ExprNode {
+	return n.parent
 }
 
 // Note: Currently only ! is a logical unary operator
@@ -129,11 +185,17 @@ type NotOpNode struct {
 	// Operand is an expression at operand of ! operator.
 	Operand ExprNode
 	tok     *Token
+	parent  ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
 func (n *NotOpNode) Token() *Token {
 	return n.tok
+}
+
+// Parent returns the parent node of this node.
+func (n *NotOpNode) Parent() ExprNode {
+	return n.parent
 }
 
 // CompareOpNodeKind is a kind of compare operators; ==, !=, <, <=, >, >=.
@@ -187,12 +249,18 @@ type CompareOpNode struct {
 	// Left is an expression for left hand side of the binary operator.
 	Left ExprNode
 	// Right is an expression for right hand side of the binary operator.
-	Right ExprNode
+	Right  ExprNode
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
 func (n *CompareOpNode) Token() *Token {
 	return n.Left.Token()
+}
+
+// Parent returns the parent node of this node.
+func (n *CompareOpNode) Parent() ExprNode {
+	return n.parent
 }
 
 // LogicalOpNodeKind is a kind of logical operators; && and ||.
@@ -225,12 +293,18 @@ type LogicalOpNode struct {
 	// Left is an expression for left hand side of the binary operator.
 	Left ExprNode
 	// Right is an expression for right hand side of the binary operator.
-	Right ExprNode
+	Right  ExprNode
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
 func (n *LogicalOpNode) Token() *Token {
 	return n.Left.Token()
+}
+
+// Parent returns the parent node of this node.
+func (n *LogicalOpNode) Parent() ExprNode {
+	return n.parent
 }
 
 // FuncCallNode represents function call in expression.
@@ -240,13 +314,19 @@ type FuncCallNode struct {
 	// functions can be called.
 	Callee string
 	// Args is arguments of the function call.
-	Args []ExprNode
-	tok  *Token
+	Args   []ExprNode
+	tok    *Token
+	parent ExprNode
 }
 
 // Token returns the first token of the node. This method is useful to get position of this node.
 func (n *FuncCallNode) Token() *Token {
 	return n.tok
+}
+
+// Parent returns the parent node of this node.
+func (n *FuncCallNode) Parent() ExprNode {
+	return n.parent
 }
 
 // VisitExprNodeFunc is a visitor function for VisitExprNode(). The entering argument is set to
@@ -275,8 +355,8 @@ func visitExprNode(n, p ExprNode, f VisitExprNodeFunc) {
 		visitExprNode(n.Left, n, f)
 		visitExprNode(n.Right, n, f)
 	case *FuncCallNode:
-		for _, a := range n.Args {
-			visitExprNode(a, n, f)
+		for i := range n.Args {
+			visitExprNode(n.Args[i], n, f)
 		}
 	}
 	f(n, p, false)

--- a/expr_ast.go
+++ b/expr_ast.go
@@ -366,3 +366,18 @@ func visitExprNode(n, p ExprNode, f VisitExprNodeFunc) {
 func VisitExprNode(n ExprNode, f VisitExprNodeFunc) {
 	visitExprNode(n, nil, f)
 }
+
+// FindParent applies predicate to each parent of this node until predicate returns true.
+// Then it returns result of predicate. If no parent found, returns nil, false.
+func FindParent[T ExprNode](n ExprNode, predicate func(n ExprNode) (T, bool)) (T, bool) {
+	parent := n.Parent()
+	for parent != nil {
+		t, ok := predicate(parent)
+		if ok {
+			return t, true
+		}
+		parent = parent.Parent()
+	}
+	var zero T
+	return zero, false
+}

--- a/expr_insecure.go
+++ b/expr_insecure.go
@@ -135,6 +135,15 @@ var BuiltinUntrustedInputs = UntrustedInputSearchRoots{
 	),
 }
 
+// Contains functions which are considered to be safe.
+// No script injection is possible if unsafe expression is used inside these functions
+// because they have stable determined output
+var safeFunctions = map[string]bool{
+	"contains":   true,
+	"startswith": true,
+	"endswith":   true,
+}
+
 // UntrustedInputChecker is a checker to detect untrusted inputs in an expression syntax tree.
 // This checker checks object property accesses, array index accesses, and object filters. And
 // detects paths to untrusted inputs. Found errors are stored in this instance and can be get via
@@ -292,8 +301,25 @@ func (u *UntrustedInputChecker) end() {
 	u.reset()
 }
 
+// IsFunctionSafe Checks if this function is safe in terms of script injection possibility when using unsafe args
+func (u *UntrustedInputChecker) IsFunctionSafe(name string) bool {
+	return safeFunctions[strings.ToLower(name)]
+}
+
 // OnVisitNodeLeave is a callback which should be called on visiting node after visiting its children.
 func (u *UntrustedInputChecker) OnVisitNodeLeave(n ExprNode) {
+	_, isInsideSafeFunctionCall := FindParent(n, func(n ExprNode) (*FuncCallNode, bool) {
+		if funcCall, ok := n.(*FuncCallNode); ok && u.IsFunctionSafe(funcCall.Callee) {
+			return funcCall, true
+		}
+		return nil, false
+	})
+
+	// Skip unsafe checks if we are inside of safe function call expression
+	if isInsideSafeFunctionCall {
+		return
+	}
+
 	switch n := n.(type) {
 	case *VariableNode:
 		u.end()

--- a/expr_insecure_test.go
+++ b/expr_insecure_test.go
@@ -193,14 +193,14 @@ func TestExprInsecureDetectUntrustedValue(t *testing.T) {
 			},
 		},
 		testCase{
-			"contains(github.event.pages.*.page_name, github.event.issue.title)",
+			"fromJson(github.event.pages.*.page_name, github.event.issue.title)",
 			[]string{
 				"github.event.pages.*.page_name",
 				"github.event.issue.title",
 			},
 		},
 		testCase{
-			"contains(github.event.*.body, github.event.*.*)",
+			"fromJson(github.event.*.body, github.event.*.*)",
 			[]string{
 				"github.event.",
 				"github.event.",
@@ -310,6 +310,14 @@ func TestExprInsecureNoUntrustedValue(t *testing.T) {
 		"matrix.foo[github.event.pages].page_name",
 		"github.event.issue.body.foo.bar",
 		"github.event.issue.body[0]",
+
+		"contains(github.event.issue.title, 'bug')",
+		"contains(github.event.issue.body, github.event.issue.title)",
+		"startsWith(github.event.comment.body, 'LGTM')",
+		"endsWith(github.event.pull_request.title, github.event.issue.title)",
+		"contains(github.event.*.body, 'sensitive')",
+		"startsWith(github.event.*.body[0], 'Important')",
+		"endsWith(github.event.commits[0].message, github.event.pull_request.title)",
 	}
 
 	for _, input := range inputs {


### PR DESCRIPTION
# Problem
Currently there are cases when `actionlint` falsely assumes expression to be unsafe when used inside scripts and warns about possible script injection.

For instance, following step description:
```yaml
- name: Determine if release branch
  run: |
    echo "is_release_branch=${{ contains(github.head_ref, 'release') }}" >> $GITHUB_OUTPUT
```
would lead to warning:
```
.github/workflows/test.yaml:17:51: "github.head_ref" is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable. see https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions for more details [expression]
```

# Why do I assume this to be false positive
The only place which I suppose relevant to the issue is this: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
Thus, if the point of this lint rule is to ensure that script injection is not possible, example above is definitely false positive.
It's false positive because there's no way for attacker to get some arbitrary output from the `contains` function.

# What is done in this PR?

1. I've added a `parent` field to every expression AST node
2. I'm using this `parent` field to traverse the AST and search for `FunctionCallNode` parents
3. If parent is found and it's `Callee` considered safe for script injection attacks - we skip all further insecure input checks in this AST leaf.

# Which functions considered safe?
Basically, I've chosen only functions which are returning booleans. Maybe there's more, but I decided to start with these:

- `contains`
- `startsWith`
- `endsWith`

# P.S.
If there's a better way to implement this - I would love to apply any fixes required for this PR to get into `main`.
I've added the `parent` to not pollute the calls to `sema.check` with additional argument just for this case.
I hope additional memory usage would not be that high, since it's just an additional pointer per AST node.