### PR TITLE
add gcr.io and pkg.dev to valid docker regstry domain

### DIFF
--- a/rule_action.go
+++ b/rule_action.go
@@ -287,6 +287,8 @@ var BrandingIcons = map[string]struct{}{
 // https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsimage
 func isImageOnDockerRegistry(image string) bool {
 	return strings.HasPrefix(image, "docker://") ||
+		strings.HasPrefix(image, "gcr.io/") ||
+		strings.HasPrefix(image, "pkg.dev/") ||
 		strings.HasPrefix(image, "ghcr.io/") ||
 		strings.HasPrefix(image, "docker.io/")
 }


### PR DESCRIPTION
## WHAT

SSIA

## Note

gcr.io and pkg.dev is docker registry domain for GCP

* gcr.io: 
https://cloud.google.com/container-registry/docs/overview
* pkg.dev
https://cloud.google.com/artifact-registry/docs
