### PR TITLE
simplify tests with cmp.Diff

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -49,8 +49,8 @@ func TestConfigParseSelfHostedRunnerOK(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !cmp.Equal(c.SelfHostedRunner.Labels, tc.labels) {
-				t.Fatal(cmp.Diff(c.SelfHostedRunner.Labels, tc.labels))
+			if diff := cmp.Diff(c.SelfHostedRunner.Labels, tc.labels); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -224,8 +224,8 @@ func TestConfigReadFileOK(t *testing.T) {
 		t.Fatal(err)
 	}
 	labels := []string{"foo", "bar"}
-	if !cmp.Equal(c.SelfHostedRunner.Labels, labels) {
-		t.Fatal(cmp.Diff(c.SelfHostedRunner.Labels, labels))
+	if diff := cmp.Diff(c.SelfHostedRunner.Labels, labels); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -488,8 +488,8 @@ func TestErrorPrintSerializedIntoJSON(t *testing.T) {
 	if err := json.Unmarshal(b.Bytes(), &decoded); err != nil {
 		t.Fatal(err)
 	}
-	if !cmp.Equal(testErrorTemplateFields, decoded) {
-		t.Fatal(cmp.Diff(testErrorTemplateFields, decoded))
+	if diff := cmp.Diff(testErrorTemplateFields, decoded); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/expr_parser_test.go
+++ b/expr_parser_test.go
@@ -596,8 +596,8 @@ func TestParseExpressionSyntaxOK(t *testing.T) {
 				t.Fatal("Parse error:", err)
 			}
 
-			if !cmp.Equal(tc.expected, n, opts...) {
-				t.Fatalf("wanted:\n%#v\n\nbut got:\n%#v\n\ndiff:\n%s\n", tc.expected, n, cmp.Diff(tc.expected, n, opts...))
+			if diff := cmp.Diff(tc.expected, n, opts...); diff != "" {
+				t.Fatalf("wanted:\n%#v\n\nbut got:\n%#v\n\ndiff:\n%s\n", tc.expected, n, diff)
 			}
 		})
 	}

--- a/expr_sema_test.go
+++ b/expr_sema_test.go
@@ -769,8 +769,8 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 				t.Fatal("semantics check failed:", errs)
 			}
 
-			if !cmp.Equal(tc.expected, ty) {
-				t.Fatalf("wanted: %s\nbut got:%s\ndiff:\n%s", tc.expected.String(), ty.String(), cmp.Diff(tc.expected, ty))
+			if diff := cmp.Diff(tc.expected, ty); diff != "" {
+				t.Fatalf("wanted: %s\nbut got:%s\ndiff:\n%s", tc.expected.String(), ty.String(), diff)
 			}
 		})
 	}

--- a/expr_type_test.go
+++ b/expr_type_test.go
@@ -812,14 +812,14 @@ func TestExprTypeMergeComplicated(t *testing.T) {
 		t.Run(tc.what, func(t *testing.T) {
 			opt := cmpopts.EquateEmpty()
 			ty := tc.with.Merge(tc.ty)
-			if !cmp.Equal(ty, tc.want, opt) {
+			if diff := cmp.Diff(tc.want, ty, opt); diff != "" {
 				t.Fatalf(
 					"%s was merged with %s as %s while expecting %s\ndiff:\n%s",
 					tc.ty.String(),
 					tc.with.String(),
 					ty.String(),
 					tc.want.String(),
-					cmp.Diff(tc.want, ty, opt),
+					diff,
 				)
 			}
 		})

--- a/linter_test.go
+++ b/linter_test.go
@@ -396,8 +396,8 @@ func TestLinterFormatErrorMessageOK(t *testing.T) {
 				have = strings.ReplaceAll(have, escaped, slash)
 			}
 
-			if !cmp.Equal(want, have) {
-				t.Fatal(cmp.Diff(want, have))
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -452,8 +452,8 @@ func TestLinterFormatErrorMessageInSARIF(t *testing.T) {
 		panic(err)
 	}
 
-	if !cmp.Equal(want, have) {
-		t.Fatal(cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/reusable_workflow_test.go
+++ b/reusable_workflow_test.go
@@ -242,8 +242,8 @@ func TestReusableWorkflowUnmarshalOK(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !cmp.Equal(m, tc.want) {
-				t.Fatal("Parse result is unexpected. diff:\n" + cmp.Diff(m, tc.want))
+			if diff := cmp.Diff(m, tc.want); diff != "" {
+				t.Fatal("Parse result is unexpected. diff:\n" + diff)
 			}
 		})
 	}
@@ -363,8 +363,8 @@ func TestReusableWorkflowCacheFindMetadataOK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !cmp.Equal(m, testReusableWorkflowWantedMetadata) {
-		t.Fatal(cmp.Diff(m, testReusableWorkflowWantedMetadata))
+	if diff := cmp.Diff(m, testReusableWorkflowWantedMetadata); diff != "" {
+		t.Fatal(diff)
 	}
 
 	m2, err := c.FindMetadata("./ok.yaml")
@@ -630,8 +630,8 @@ func TestReusableWorkflowMetadataFromASTNodeInputs(t *testing.T) {
 				t.Fatal("Event was not converted to event")
 			}
 
-			if !cmp.Equal(m.Inputs, tc.want) {
-				t.Error(cmp.Diff(m.Inputs, tc.want))
+			if diff := cmp.Diff(m.Inputs, tc.want); diff != "" {
+				t.Fatal(diff)
 			}
 			if len(m.Outputs) != 0 {
 				t.Error("Outputs are not empty", m.Outputs)
@@ -674,8 +674,8 @@ func TestReusableWorkflowMetadataFromASTNodeOutputs(t *testing.T) {
 				want[strings.ToLower(o)] = &ReusableWorkflowMetadataOutput{o}
 			}
 
-			if !cmp.Equal(m.Outputs, want) {
-				t.Error(cmp.Diff(m.Outputs, want))
+			if diff := cmp.Diff(m.Outputs, want); diff != "" {
+				t.Fatal(diff)
 			}
 			if len(m.Inputs) != 0 {
 				t.Error("Inputs are not empty", m.Inputs)
@@ -733,8 +733,8 @@ func TestReusableWorkflowMetadataFromASTNodeSecrets(t *testing.T) {
 				}
 			}
 
-			if !cmp.Equal(m.Secrets, want) {
-				t.Error(cmp.Diff(m.Secrets, want))
+			if diff := cmp.Diff(m.Secrets, want); diff != "" {
+				t.Fatal(diff)
 			}
 			if len(m.Inputs) != 0 {
 				t.Error("Inputs are not empty", m.Inputs)
@@ -811,8 +811,8 @@ func TestReusableWorkflowMetadataCacheFindOneMetadataConcurrently(t *testing.T) 
 	}
 
 	for _, m := range ms {
-		if !cmp.Equal(testReusableWorkflowWantedMetadata, m) {
-			t.Fatal(cmp.Diff(testReusableWorkflowWantedMetadata, m))
+		if diff := cmp.Diff(testReusableWorkflowWantedMetadata, m); diff != "" {
+			t.Fatal(diff)
 		}
 	}
 

--- a/rule_deprecated_commands_test.go
+++ b/rule_deprecated_commands_test.go
@@ -117,8 +117,8 @@ func TestRuleDeprecatedCommandsDetectTargetCommands(t *testing.T) {
 				have = append(have, ss[1])
 			}
 
-			if !cmp.Equal(have, tc.want) {
-				t.Fatal(cmp.Diff(have, tc.want))
+			if diff := cmp.Diff(have, tc.want); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/rule_workflow_call_test.go
+++ b/rule_workflow_call_test.go
@@ -152,8 +152,8 @@ func TestRuleWorkflowCallWriteEventNodeToMetadataCache(t *testing.T) {
 		},
 	}
 
-	if !cmp.Equal(want, m) {
-		t.Fatal(cmp.Diff(want, m))
+	if diff := cmp.Diff(want, m); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/scripts/check-checks/main_test.go
+++ b/scripts/check-checks/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"io"
 	"log"
 	"os"
@@ -58,8 +57,8 @@ func TestMainGenerateOK(t *testing.T) {
 
 	want := must(os.ReadFile(filepath.FromSlash("testdata/ok/minimal.out")))
 	have := must(os.ReadFile(path))
-	if !bytes.Equal(want, have) {
-		t.Fatal(cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
 	}
 }
 
@@ -141,8 +140,8 @@ func TestUpdateOK(t *testing.T) {
 				t.Fatal(err)
 			}
 			want := must(os.ReadFile(out))
-			if !bytes.Equal(want, have) {
-				t.Fatal(cmp.Diff(want, have))
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/scripts/generate-availability/main_test.go
+++ b/scripts/generate-availability/main_test.go
@@ -32,8 +32,8 @@ func TestOKWriteStdout(t *testing.T) {
 	}
 	want := string(b)
 
-	if stdout != want {
-		t.Fatal(cmp.Diff(want, stdout))
+	if diff := cmp.Diff(stdout, want); diff != "" {
+		t.Fatal(diff)
 	}
 }
 
@@ -63,8 +63,8 @@ func TestOKWriteFile(t *testing.T) {
 	}
 	have := string(b)
 
-	if want != have {
-		t.Fatal(cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/scripts/generate-popular-actions/main_test.go
+++ b/scripts/generate-popular-actions/main_test.go
@@ -89,8 +89,8 @@ func TestReadWriteJSONL(t *testing.T) {
 			want := string(b)
 			have := stdout.String()
 
-			if want != have {
-				t.Fatalf("read content and output content differ\n%s", cmp.Diff(want, have))
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Fatalf("read content and output content differ\n%s", diff)
 			}
 		})
 	}
@@ -139,8 +139,8 @@ func TestWriteGoToStdout(t *testing.T) {
 			want := string(b)
 			have := stdout.String()
 
-			if want != have {
-				t.Fatalf("read content and output content differ\n%s", cmp.Diff(want, have))
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Fatalf("read content and output content differ\n%s", diff)
 			}
 		})
 	}
@@ -170,8 +170,8 @@ func TestWriteJSONLFile(t *testing.T) {
 	}
 	have := string(b)
 
-	if want != have {
-		t.Fatalf("read content and output content differ\n%s", cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatalf("read content and output content differ\n%s", diff)
 	}
 }
 
@@ -199,8 +199,8 @@ func TestWriteGoFile(t *testing.T) {
 	}
 	have := string(b)
 
-	if want != have {
-		t.Fatalf("read content and output content differ\n%s", cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatalf("read content and output content differ\n%s", diff)
 	}
 }
 
@@ -231,8 +231,8 @@ func TestFetchRemoteYAML(t *testing.T) {
 			want := string(b)
 			have := stdout.String()
 
-			if !cmp.Equal(want, have) {
-				t.Fatalf("fetched JSONL data does not match: %s", cmp.Diff(want, have))
+			if diff := cmp.Diff(want, have); diff != "" {
+				t.Fatalf("fetched JSONL data does not match: %s", diff)
 			}
 		})
 	}
@@ -252,8 +252,8 @@ func TestWriteOutdatedActionAsJSONL(t *testing.T) {
 		panic(err)
 	}
 	want, have := string(b), stdout.String()
-	if want != have {
-		t.Fatal(cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/scripts/generate-webhook-events/main_test.go
+++ b/scripts/generate-webhook-events/main_test.go
@@ -32,8 +32,8 @@ func TestOKWriteStdout(t *testing.T) {
 	}
 	want := string(b)
 
-	if stdout != want {
-		t.Fatal(cmp.Diff(want, stdout))
+	if diff := cmp.Diff(want, stdout); diff != "" {
+		t.Fatal(diff)
 	}
 }
 
@@ -63,8 +63,8 @@ func TestOKWriteFile(t *testing.T) {
 	}
 	have := string(b)
 
-	if want != have {
-		t.Fatal(cmp.Diff(want, have))
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
 	}
 }
 


### PR DESCRIPTION
This PR refactors tests. These code blocks
```go
if !cmp.Equal(want, got) {
	t.Fatal(cmp.Diff(want, got))
}
```

```go
if !bytes.Equal(want, got) {
	t.Fatal(cmp.Diff(want, got))
}
```

```go
if want != got {
	t.Fatal(cmp.Diff(want, got))
}
```

changed to the following:

```go
if diff := cmp.Diff(want, got); diff != "" {
	t.Fatal(diff)
}
```