### PR TITLE
refactor tests to use t.Fatal instead of panic

### DIFF
--- a/expr_test.go
+++ b/expr_test.go
@@ -10,7 +10,7 @@ import (
 func TestExprSemanticsCheckRealWorld(t *testing.T) {
 	f, err := os.Open(filepath.Join("testdata", "bench", "expressions.txt"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	defer f.Close()
 

--- a/linter_test.go
+++ b/linter_test.go
@@ -30,7 +30,7 @@ func TestLinterLintOK(t *testing.T) {
 
 	es, err := os.ReadDir(dir)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	fs := make([]string, 0, len(es))
@@ -108,14 +108,14 @@ func checkErrors(t *testing.T, outfile string, errs []*Error) {
 	{
 		f, err := os.Open(outfile)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 		s := bufio.NewScanner(f)
 		for s.Scan() {
 			expected = append(expected, s.Text())
 		}
 		if err := s.Err(); err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 	}
 
@@ -149,7 +149,7 @@ func TestLinterLintError(t *testing.T) {
 	for _, subdir := range []string{"examples", "err"} {
 		dir, infiles, err := testFindAllWorkflowsInDir(subdir)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 
 		proj := &Project{root: dir}
@@ -170,7 +170,7 @@ func TestLinterLintError(t *testing.T) {
 			t.Run(subdir+"/"+testName, func(t *testing.T) {
 				b, err := os.ReadFile(infile)
 				if err != nil {
-					panic(err)
+					t.Fatal(err)
 				}
 
 				o := LinterOptions{}
@@ -220,7 +220,7 @@ func TestLinterLintAllErrorWorkflowsAtOnce(t *testing.T) {
 
 	dir, files, err := testFindAllWorkflowsInDir("examples")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	// Root directory must be testdata/examples/ since some workflow assumes it
@@ -228,7 +228,7 @@ func TestLinterLintAllErrorWorkflowsAtOnce(t *testing.T) {
 
 	_, fs, err := testFindAllWorkflowsInDir("err")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	files = append(files, fs...)
 
@@ -268,10 +268,10 @@ func TestLintFindProjectFromPath(t *testing.T) {
 	f := filepath.Join(d, ".github", "workflows", "test.yaml")
 	b, err := os.ReadFile(f)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
-	testEnsureDotGitDir(d)
+	testEnsureDotGitDir(t, d)
 
 	lint := func(path string) []*Error {
 		l, err := NewLinter(io.Discard, &LinterOptions{})
@@ -306,7 +306,7 @@ func TestLinterLintProject(t *testing.T) {
 	root := filepath.Join("testdata", "projects")
 	entries, err := os.ReadDir(root)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	for _, info := range entries {
@@ -383,7 +383,7 @@ func TestLinterFormatErrorMessageOK(t *testing.T) {
 
 			buf, err := os.ReadFile(filepath.Join(dir, tc.file))
 			if err != nil {
-				panic(err)
+				t.Fatal(err)
 			}
 			want := string(buf)
 
@@ -410,7 +410,7 @@ func TestLinterFormatErrorMessageInSARIF(t *testing.T) {
 
 	bytes, err := os.ReadFile(filepath.Join(dir, "sarif_template.txt"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	format := string(bytes)
 
@@ -445,11 +445,11 @@ func TestLinterFormatErrorMessageInSARIF(t *testing.T) {
 
 	bytes, err = os.ReadFile(filepath.Join(dir, "test.sarif"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	var want interface{}
 	if err := json.Unmarshal(bytes, &want); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	if !cmp.Equal(want, have) {
@@ -512,7 +512,7 @@ func TestLinterPathsNotFound(t *testing.T) {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	paths := []string{
@@ -642,7 +642,7 @@ func TestLinterGenerateDefaultConfigAlreadyExists(t *testing.T) {
 
 	for _, n := range []string{"ok", "yml"} {
 		d := filepath.Join("testdata", "config", "projects", n)
-		testEnsureDotGitDir(d)
+		testEnsureDotGitDir(t, d)
 
 		err := l.GenerateDefaultConfig(d)
 		if err == nil {
@@ -673,7 +673,7 @@ func BenchmarkLintWorkflowFiles(b *testing.B) {
 		d := filepath.Join(".github", "workflows")
 		es, err := os.ReadDir(d)
 		if err != nil {
-			panic(err)
+			b.Fatal(err)
 		}
 		for _, e := range es {
 			ours = append(ours, filepath.Join(d, e.Name()))
@@ -796,7 +796,7 @@ func BenchmarkLintWorkflowFiles(b *testing.B) {
 func BenchmarkLintWorkflowContent(b *testing.B) {
 	dir, err := os.Getwd()
 	if err != nil {
-		panic(err)
+		b.Fatal(err)
 	}
 	proj := &Project{root: dir}
 
@@ -841,7 +841,7 @@ func BenchmarkLintWorkflowContent(b *testing.B) {
 func BenchmarkExamplesLintFiles(b *testing.B) {
 	dir, files, err := testFindAllWorkflowsInDir("examples")
 	if err != nil {
-		panic(err)
+		b.Fatal(err)
 	}
 
 	proj := &Project{root: dir}

--- a/project_test.go
+++ b/project_test.go
@@ -12,10 +12,10 @@ import (
 // doesn't exist. When cloning actionlint repository with Git, it never happens. However, when
 // downloading sources tarball from github.com, it doesn't contain `.git` directory so it
 // happens. Please see #307 for more details.
-func testEnsureDotGitDir(dir string) {
+func testEnsureDotGitDir(t *testing.T, dir string) {
 	d := filepath.Join(dir, ".git")
 	if err := os.MkdirAll(d, 0750); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 }
 
@@ -23,9 +23,9 @@ func TestProjectsFindProjectFromPath(t *testing.T) {
 	d := filepath.Join("testdata", "find_project")
 	abs, err := filepath.Abs(d)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	testEnsureDotGitDir(d)
+	testEnsureDotGitDir(t, d)
 
 	ps := NewProjects()
 	for _, tc := range []struct {
@@ -84,9 +84,9 @@ func TestProjectsDoesNotFindProjectFromOutside(t *testing.T) {
 	d := filepath.Join("testdata", "find_project")
 	abs, err := filepath.Abs(d)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	testEnsureDotGitDir(d)
+	testEnsureDotGitDir(t, d)
 
 	outside := filepath.Join(d, "..")
 	ps := NewProjects()
@@ -102,7 +102,7 @@ func TestProjectsDoesNotFindProjectFromOutside(t *testing.T) {
 func TestProjectsLoadProjectConfig(t *testing.T) {
 	for _, n := range []string{"ok", "yml"} {
 		d := filepath.Join("testdata", "config", "projects", n)
-		testEnsureDotGitDir(d)
+		testEnsureDotGitDir(t, d)
 		ps := NewProjects()
 		p, err := ps.At(d)
 		if err != nil {
@@ -119,7 +119,7 @@ func TestProjectsLoadProjectConfig(t *testing.T) {
 
 func TestProjectsLoadingNoProjectConfig(t *testing.T) {
 	d := filepath.Join("testdata", "config", "projects", "none")
-	testEnsureDotGitDir(d)
+	testEnsureDotGitDir(t, d)
 	ps := NewProjects()
 	p, err := ps.At(d)
 	if err != nil {
@@ -136,7 +136,7 @@ func TestProjectsLoadingNoProjectConfig(t *testing.T) {
 func TestProjectsLoadingBrokenProjectConfig(t *testing.T) {
 	want := "could not parse config file"
 	d := filepath.Join("testdata", "config", "projects", "err")
-	testEnsureDotGitDir(d)
+	testEnsureDotGitDir(t, d)
 	ps := NewProjects()
 	p, err := ps.At(d)
 	if err == nil {

--- a/scripts/generate-availability/main_test.go
+++ b/scripts/generate-availability/main_test.go
@@ -28,7 +28,7 @@ func TestOKWriteStdout(t *testing.T) {
 
 	b, err := os.ReadFile(filepath.Join("testdata", "ok.go"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	want := string(b)
 
@@ -49,7 +49,7 @@ func TestOKWriteFile(t *testing.T) {
 
 	b, err := os.ReadFile(filepath.Join("testdata", "ok.go"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	want := string(b)
 

--- a/scripts/generate-popular-actions/main_test.go
+++ b/scripts/generate-popular-actions/main_test.go
@@ -84,7 +84,7 @@ func TestReadWriteJSONL(t *testing.T) {
 
 			b, err := os.ReadFile(f)
 			if err != nil {
-				panic(err)
+				t.Fatal(err)
 			}
 			want := string(b)
 			have := stdout.String()
@@ -134,7 +134,7 @@ func TestWriteGoToStdout(t *testing.T) {
 
 			b, err := os.ReadFile(filepath.Join("testdata", "go", tc.want))
 			if err != nil {
-				panic(err)
+				t.Fatal(err)
 			}
 			want := string(b)
 			have := stdout.String()
@@ -150,7 +150,7 @@ func TestWriteJSONLFile(t *testing.T) {
 	in := filepath.Join("testdata", "jsonl", "no_new_version.jsonl")
 	b, err := os.ReadFile(in)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 
 	out := filepath.Join("testdata", "out.jsonl")
@@ -189,7 +189,7 @@ func TestWriteGoFile(t *testing.T) {
 
 	b, err := os.ReadFile(filepath.Join("testdata", "go", "no_new_version.go"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	want := string(b)
 
@@ -226,7 +226,7 @@ func TestFetchRemoteYAML(t *testing.T) {
 
 			b, err := os.ReadFile(filepath.Join("testdata", "go", tc.want))
 			if err != nil {
-				panic(err)
+				t.Fatal(err)
 			}
 			want := string(b)
 			have := stdout.String()
@@ -249,7 +249,7 @@ func TestWriteOutdatedActionAsJSONL(t *testing.T) {
 
 	b, err := os.ReadFile(filepath.Join("testdata", "jsonl", "outdated.jsonl"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	want, have := string(b), stdout.String()
 	if want != have {

--- a/scripts/generate-webhook-events/main_test.go
+++ b/scripts/generate-webhook-events/main_test.go
@@ -28,7 +28,7 @@ func TestOKWriteStdout(t *testing.T) {
 
 	b, err := os.ReadFile(filepath.Join("testdata", "ok.go"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	want := string(b)
 
@@ -49,7 +49,7 @@ func TestOKWriteFile(t *testing.T) {
 
 	b, err := os.ReadFile(filepath.Join("testdata", "ok.go"))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	want := string(b)
 


### PR DESCRIPTION
[`t.Fatal`](https://pkg.go.dev/testing#T.Fatal) is specifically designed for use in tests instead of `panic`. It stops tests execution immediately.