### PR TITLE
Add `shellcheck` dependency in pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
   files: ^\.github/workflows/
   entry: actionlint
   minimum_pre_commit_version: 3.0.0
-  additional_dependencies: ["shellcheck"]
+  additional_dependencies: ["github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest"]
 - id: actionlint-docker
   name: Lint GitHub Actions workflow files
   description: Runs actionlint Docker image to lint GitHub Actions workflow files

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
   files: ^\.github/workflows/
   entry: actionlint
   minimum_pre_commit_version: 3.0.0
+  additional_dependencies: ["shellcheck"]
 - id: actionlint-docker
   name: Lint GitHub Actions workflow files
   description: Runs actionlint Docker image to lint GitHub Actions workflow files


### PR DESCRIPTION
Fixes #477 

This pull request adds the `github.com/wasilibs/go-shellcheck/cmd/shellcheck@latest` package as a dependency for actionlint `pre-commit` hooks. This change resolves the issue reported in #477.

Please note that I'm not familiar with Go and may not have chosen the most optimal dependency package. If you have a better approach, please let me know and I'll be happy to update the code.
