### PR TITLE
Support branding.color "black"

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -2830,7 +2830,7 @@ branding:
   # ERROR: Invalid icon name
   icon: dog
   # ERROR: Unsupported icon color
-  color: black
+  color: gray-white
 
 runs:
   # ERROR: Node.js runtime version is too old
@@ -2867,7 +2867,7 @@ test.yaml:8:15: incorrect icon name "dog" at branding.icon in metadata of "My ac
   |
 8 |       - uses: ./.github/actions/my-invalid-action
   |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-test.yaml:8:15: incorrect color "black" at branding.icon in metadata of "My action" action at "/Users/rhysd/.go/src/github.com/rhysd/actionlint/.github/actions/my-invalid-action/action.yml". see the official document to know the exhaustive list of supported colors: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#brandingcolor [action]
+test.yaml:8:15: incorrect color "gray-white" at branding.icon in metadata of "My action" action at "/Users/rhysd/.go/src/github.com/rhysd/actionlint/.github/actions/my-invalid-action/action.yml". see the official document to know the exhaustive list of supported colors: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#brandingcolor [action]
   |
 8 |       - uses: ./.github/actions/my-invalid-action
   |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/rule_action.go
+++ b/rule_action.go
@@ -14,6 +14,7 @@ import (
 // https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#brandingcolor
 var BrandingColors = map[string]struct{}{
 	"white":     {},
+	"black":     {},
 	"yellow":    {},
 	"blue":      {},
 	"green":     {},

--- a/testdata/examples/.github/actions/my-invalid-action/action.yml
+++ b/testdata/examples/.github/actions/my-invalid-action/action.yml
@@ -8,7 +8,7 @@ branding:
   # ERROR: Invalid icon name
   icon: dog
   # ERROR: Unsupported icon color
-  color: black
+  color: gray-white
 
 runs:
   # ERROR: Node.js runtime version is too old

--- a/testdata/examples/action_metadata_syntax_validation.out
+++ b/testdata/examples/action_metadata_syntax_validation.out
@@ -1,6 +1,6 @@
 /test\.yaml:8:15: description is required in metadata of "My action" action at ".+(\\\\|/)my-invalid-action(\\\\|/)action\.yml" \[action\]/
 /test\.yaml:8:15: incorrect icon name "dog" at branding\.icon in metadata of "My action" action at ".+(\\\\|/)my-invalid-action(\\\\|/)action\.yml"\. see the official document to know the exhaustive list of supported icons: https://.+ \[action\]/
-/test\.yaml:8:15: incorrect color "black" at branding\.icon in metadata of "My action" action at ".+(\\\\|/)my-invalid-action(\\\\|/)action\.yml"\. see the official document to know the exhaustive list of supported colors: https://.+ \[action\]/
+/test\.yaml:8:15: incorrect color "gray-white" at branding\.icon in metadata of "My action" action at ".+(\\\\|/)my-invalid-action(\\\\|/)action\.yml"\. see the official document to know the exhaustive list of supported colors: https://.+ \[action\]/
 /test\.yaml:8:15: invalid runner name \"node14\" at runs\.using in \"My action\" action defined at \".+(\\\\|/)actions(\\\\|/)my-invalid-action\"\. valid runners are \"composite\", \"docker\", and \"node20\"\. see https://.+ \[action\]/
 /test\.yaml:8:15: file "this-file-does-not-exist\.js" does not exist in ".+(\\\\|/)my-invalid-action"\. it is specified at "main" key in "runs" section in "My action" action \[action\]/
 /test\.yaml:8:15: "env" is not allowed in "runs" section because "My action" is a JavaScript action\. the action is defined at ".+(\\\\|/)my-invalid-action" \[action\]/


### PR DESCRIPTION
The official GitHub documentation lists it as a supported color: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#brandingcolor 

Fixes: #484