### PR TITLE
fix: Add undocumented github.repository_visibility option

### DIFF
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -230,6 +230,7 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 		"repository_owner":    StringType{},
 		"repository_owner_id": StringType{},
 		"repositoryurl":       StringType{}, // repositoryUrl
+		"repository_visibility": StringType{},
 		"retention_days":      NumberType{},
 		"run_id":              StringType{},
 		"run_number":          StringType{},


### PR DESCRIPTION
See https://www.google.com/search?q=github+%22repository_visibility%22

As a workaround, one can add this to your `actionlint.yml` file:
```yaml
paths:
  # This pattern matches any YAML file under the '.github/workflows/' directory.
  .github/workflows/**/*:
    ignore:
      # Ignore undocumented option repository_visibility.
      - 'repository_visibility'
```