### PR TITLE
Run unit test GitHub Action on an ARM processor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     name: Unit tests
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, macos-13]
         go: ['1.22', '1.23']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Projects are speeding up GitHub Actions by running them on an ARM processor. https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources