### PR TITLE
Fix lint for attest-build-provenance action

### DIFF
--- a/popular_actions.go
+++ b/popular_actions.go
@@ -284,12 +284,13 @@ var PopularActions = map[string]*ActionMetadata{
 	"actions/attest-build-provenance@v2": {
 		Name: "Attest Build Provenance",
 		Inputs: ActionMetadataInputs{
-			"github-token":     {"github-token", false},
-			"push-to-registry": {"push-to-registry", false},
-			"show-summary":     {"show-summary", false},
-			"subject-digest":   {"subject-digest", false},
-			"subject-name":     {"subject-name", false},
-			"subject-path":     {"subject-path", false},
+			"github-token":      {"github-token", false},
+			"push-to-registry":  {"push-to-registry", false},
+			"show-summary":      {"show-summary", false},
+			"subject-checksums": {"subject-checksums", false},
+			"subject-digest":    {"subject-digest", false},
+			"subject-name":      {"subject-name", false},
+			"subject-path":      {"subject-path", false},
 		},
 		Outputs: ActionMetadataOutputs{
 			"attestation-id":  {"attestation-id"},


### PR DESCRIPTION
This should fix a false positive for a popular [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance) action.

Error message from [Super Linter](https://github.com/super-linter/super-linter/) that uses `actionlint` under the hood:

```
  ------
  .github/workflows/release.yaml:51:11: input "subject-checksums" is not defined in action "actions/attest-build-provenance@v2". available inputs are "github-token", "push-to-registry", "show-summary", "subject-digest", "subject-name", "subject-path" [action]
     |
  51 |           subject-checksums: ./dist/checksums.txt
     |           ^~~~~~~~~~~~~~~~~~
  ------
```

Meanwhile, the [action README](https://github.com/actions/attest-build-provenance?tab=readme-ov-file#inputs) says:

```
...

    # Path to checksums file containing digest and name of subjects for
    # attestation. Must specify exactly one of "subject-path", "subject-digest",
    # or "subject-checksums".
    subject-checksums:
...
```