### PR TITLE
chore: add support for additional github action input parameters

### DIFF
--- a/action_metadata.go
+++ b/action_metadata.go
@@ -36,6 +36,7 @@ func (inputs *ActionMetadataInputs) UnmarshalYAML(n *yaml.Node) error {
 	type actionInputMetadata struct {
 		Required bool    `yaml:"required"`
 		Default  *string `yaml:"default"`
+		DeprecationMessage *string `yaml:"deprecationMessage"`
 	}
 
 	md := make(ActionMetadataInputs, len(n.Content)/2)


### PR DESCRIPTION
This PR adds support for the `deprecationMessage` input parameter under the `inputs` section for reusable workflows triggered via `workflow_call`.

### Background

GitHub supports [deprecationMessage](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputsinput\_iddeprecationmessage) field in the metadata syntax for reusable workflows. This field allows maintainers to mark inputs as deprecated and provide contextual messaging for downstream consumers.

However, `actionlint` currently treats `deprecationMessage` as an unknown key and fails with the following error:

```
unexpected key "deprecationMessage" for "inputs at workflow_call event" section. expected one of "default", "description", "required", "type" [syntax-check]
```

This causes valid GitHub workflows using the new field to fail `actionlint` checks.

### Fix

This PR updates the schema validation logic to recognize `deprecationMessage` as a valid optional field within the `inputs` section for `workflow_call`.

