### PR TITLE
Optimistically match shellcheck errors to source

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -40,6 +40,8 @@ type String struct {
 	Quoted bool
 	// Pos is a position of the string in source.
 	Pos *Pos
+	// If string is a literal block which preserves newlines and indentation. Helpful for error messages
+	Literal bool
 }
 
 // ContainsExpression checks if the given string contains a ${{ }} placeholder or not. This function

--- a/parse.go
+++ b/parse.go
@@ -38,7 +38,8 @@ func isNull(n *yaml.Node) bool {
 
 func newString(n *yaml.Node) *String {
 	quoted := n.Style&(yaml.DoubleQuotedStyle|yaml.SingleQuotedStyle) != 0
-	return &String{n.Value, quoted, posAt(n)}
+	literal := n.Style == yaml.LiteralStyle
+	return &String{n.Value, quoted, posAt(n), literal}
 }
 
 type workflowKeyVal struct {
@@ -137,7 +138,7 @@ func (p *parser) mayParseExpression(n *yaml.Node) *String {
 
 func (p *parser) parseString(n *yaml.Node, allowEmpty bool) *String {
 	if !p.checkString(n, allowEmpty) {
-		return &String{"", false, posAt(n)}
+		return &String{"", false, posAt(n), false}
 	}
 	return newString(n)
 }

--- a/rule_runner_label.go
+++ b/rule_runner_label.go
@@ -266,7 +266,7 @@ func (rule *RuleRunnerLabel) tryToGetLabelsInMatrix(label *String, m *Matrix) []
 		if row, ok := m.Rows[prop]; ok {
 			for _, v := range row.Values {
 				if s, ok := v.(*RawYAMLString); ok && !ContainsExpression(s.Value) {
-					labels = append(labels, &String{s.Value, false, s.Pos()})
+					labels = append(labels, &String{s.Value, false, s.Pos(), false})
 				}
 			}
 		}
@@ -277,7 +277,7 @@ func (rule *RuleRunnerLabel) tryToGetLabelsInMatrix(label *String, m *Matrix) []
 			if combi.Assigns != nil {
 				if assign, ok := combi.Assigns[prop]; ok {
 					if s, ok := assign.Value.(*RawYAMLString); ok && !ContainsExpression(s.Value) {
-						labels = append(labels, &String{s.Value, false, s.Pos()})
+						labels = append(labels, &String{s.Value, false, s.Pos(), false})
 					}
 				}
 			}

--- a/rule_runner_label_test.go
+++ b/rule_runner_label_test.go
@@ -255,7 +255,7 @@ func TestRuleRunnerLabelCheckLabels(t *testing.T) {
 			pos := &Pos{}
 			labels := make([]*String, 0, len(tc.labels))
 			for _, l := range tc.labels {
-				labels = append(labels, &String{l, false, pos})
+				labels = append(labels, &String{l, false, pos, false})
 			}
 			node := &Job{
 				RunsOn: &Runner{
@@ -264,7 +264,7 @@ func TestRuleRunnerLabelCheckLabels(t *testing.T) {
 			}
 
 			if tc.matrix != nil {
-				n := &String{"os", false, pos}
+				n := &String{"os", false, pos, false}
 				row := make([]RawYAMLValue, 0, len(tc.matrix))
 				for _, m := range tc.matrix {
 					row = append(row, &RawYAMLString{m, pos})

--- a/rule_shellcheck.go
+++ b/rule_shellcheck.go
@@ -3,6 +3,7 @@ package actionlint
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 )
@@ -57,7 +58,7 @@ func (rule *RuleShellcheck) VisitStep(n *Step) error {
 		return nil
 	}
 
-	rule.runShellcheck(run.Run.Value, rule.getShellName(run), run.RunPos)
+	rule.runShellcheck(run.Run, rule.getShellName(run), run.RunPos)
 	return nil
 }
 
@@ -160,7 +161,7 @@ func sanitizeExpressionsInScript(src string) string {
 	}
 }
 
-func (rule *RuleShellcheck) runShellcheck(src, shell string, pos *Pos) {
+func (rule *RuleShellcheck) runShellcheck(srcAst *String, shell string, pos *Pos) {
 	var sh string
 	if shell == "bash" || shell == "sh" {
 		sh = shell
@@ -172,6 +173,7 @@ func (rule *RuleShellcheck) runShellcheck(src, shell string, pos *Pos) {
 		return // Skip checking this shell script since shellcheck doesn't support it
 	}
 
+	src := srcAst.Value
 	src = sanitizeExpressionsInScript(src)
 	rule.Debug("%s: Run shellcheck for %s script:\n%s", pos, sh, src)
 
@@ -214,6 +216,8 @@ func (rule *RuleShellcheck) runShellcheck(src, shell string, pos *Pos) {
 			return nil
 		}
 
+		rule.EnableDebug(os.Stdout)
+
 		// Synchronize rule.Errorf calls
 		rule.mu.Lock()
 		defer rule.mu.Unlock()
@@ -227,7 +231,14 @@ func (rule *RuleShellcheck) runShellcheck(src, shell string, pos *Pos) {
 			// Consider the first line is setup for running shell which was implicitly added for better check
 			line := err.Line - 1
 			msg := strings.TrimSuffix(err.Message, ".") // Trim period aligning style of error message
-			rule.Errorf(pos, "shellcheck reported issue in this script: SC%d:%s:%d:%d: %s", err.Code, err.Level, line, err.Column, msg)
+
+			var errorLocation Pos
+			if srcAst.Literal {
+				errorLocation = Pos{line + srcAst.Pos.Line, err.Column + srcAst.Pos.Col - 4}
+			} else {
+				errorLocation = *pos
+			}
+			rule.Errorf(&errorLocation, "shellcheck reported issue in this script: SC%d:%s:%d:%d: %s", err.Code, err.Level, line, err.Column, msg)
 		}
 
 		return nil


### PR DESCRIPTION
Addresses https://github.com/rhysd/actionlint/issues/360

The yaml ast node exposes if the string nodes are literals or not. If so, we can preserve shellcheck errors to their source in the yaml block rather than just the `runs:` key.

Example from sqlite-jdbc:

```yaml
      - name: Build matrix from Makefile
        id: set-matrix
        # parse the Makefile to retrieve the list of targets in 'native-all', without 'native'
        run: |
          matrix=$((
            echo '{ "target" : ['
            sed -n "/^native-all *: */ { s///; p }" Makefile | sed "s/^native\s//g" | sed 's/ /, /g' | xargs -n 1 echo | sed -r 's/^([^,]*)(,?)$/"\1"\2/'
            echo " ]}"
          ) | jq -c .)
          echo $matrix | jq .
          echo "matrix=$matrix" >> $GITHUB_OUTPUT
```

output of

```
❯ actionlint -version
v1.7.7
installed by building from source
built with go1.21.6 compiler for darwin/arm64
```

```
.github/workflows/build-native.yml:68:9: shellcheck reported issue in this script: SC1102:error:1:8: Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors [shellcheck]
   |
68 |         run: |
   |         ^~~~
.github/workflows/build-native.yml:68:9: shellcheck reported issue in this script: SC2086:info:6:6: Double quote to prevent globbing and word splitting [shellcheck]
   |
68 |         run: |
   |         ^~~~
.github/workflows/build-native.yml:68:9: shellcheck reported issue in this script: SC2086:info:7:26: Double quote to prevent globbing and word splitting [shellcheck]
   |
68 |         run: |
   |         ^~~~
```

Output from this branch:

```
.github/workflows/build-native.yml:69:18: shellcheck reported issue in this script: SC1102:error:1:8: Shells disambiguate $(( differently or not at all. For $(command substitution), add space after $( . For $((arithmetics)), fix parsing errors [shellcheck]
   |
69 |           matrix=$((
   |                  ^~~
.github/workflows/build-native.yml:74:16: shellcheck reported issue in this script: SC2086:info:6:6: Double quote to prevent globbing and word splitting [shellcheck]
   |
74 |           echo $matrix | jq .
   |                ^~~~~~~
.github/workflows/build-native.yml:75:36: shellcheck reported issue in this script: SC2086:info:7:26: Double quote to prevent globbing and word splitting [shellcheck]
   |
75 |           echo "matrix=$matrix" >> $GITHUB_OUTPUT
   |                                    ^~~~~~~~~~~~~~
```

The difference becomes incredibly stark with greater than 10 errors. The existing output feels empty.

i don't beleive this is ready to merge as is. I'm a newcomer to the go language so I expect the code is not idiomatic. This project also has excellent testing coverage and documentation that this changeset does not come close to as is.

My first question is if you are open to this change. If so, I am very interseted in your thoughts to get this to the quality you like. Things that might be of interest:
- put this feature behind a flag
- gather shell scripts from top 1000 github repos and see the results similar to the popular actions
- extensive tests in testdata with expected output
- update the documentation examples to generate output
- extend this to pyflakes mechanism

Thank you for the project

<details>
<summary> Screenshots to give visceral feel </summary>


#### sqlite-jdbc

##### current
<img width="1840" height="1179" alt="image" src="https://github.com/user-attachments/assets/94f662c4-64c6-4009-8be3-6b5ca73b6095" />

##### proposed
<img width="1840" height="1179" alt="image" src="https://github.com/user-attachments/assets/484a727a-1874-46dd-b7e7-1159c1900c31" />



#### liquibase

##### current
<img width="1840" height="1179" alt="image" src="https://github.com/user-attachments/assets/d7101a76-d4ff-4368-8137-2b1d078887dd" />

##### proposed
<img width="1840" height="1179" alt="image" src="https://github.com/user-attachments/assets/085a1a5b-4748-4f65-9a0b-a6acf576f90d" />


#### druid
##### current
<img width="1840" height="1179" alt="image" src="https://github.com/user-attachments/assets/c929e6b4-adcf-49a6-9336-b715e125f044" />

##### proposed
<img width="1840" height="1179" alt="image" src="https://github.com/user-attachments/assets/881157f0-65e2-4d1d-a30a-11236b30ea77" />


</details>