### PR TITLE
feat: Support YAML anchors and aliases in parser

### DIFF
--- a/linter_test.go
+++ b/linter_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"golang.org/x/sys/execabs"
 )
 
@@ -459,7 +460,15 @@ func TestLinterFormatErrorMessageInSARIF(t *testing.T) {
 		panic(err)
 	}
 
-	if diff := cmp.Diff(want, have); diff != "" {
+	if diff := cmp.Diff(
+		want,
+		have,
+		cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
+			// Built version is not stable across Go versions and environments.
+			// To avoid this instability, ignore "version" field in SARIF.
+			return k == "version"
+		}),
+	); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/playground/test.ts
+++ b/playground/test.ts
@@ -67,7 +67,7 @@ jobs:
 
         // Do not `await` this method call since it will never be settled
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        go.run(result.instance);
+        go.run('instance' in result ? (result as { instance: WebAssembly.Instance }).instance : result);
     });
 
     it('shows first result on loading', async function () {

--- a/testdata/ok/yaml_anchors.yaml
+++ b/testdata/ok/yaml_anchors.yaml
@@ -1,0 +1,10 @@
+on: push
+jobs:
+  test:
+    runs-on: &runs_on ubuntu-latest
+    steps:
+      - run: "echo 'hello'"
+  test2:
+    runs-on: *runs_on
+    steps:
+      - run: "echo 'world'"


### PR DESCRIPTION
This change adds support for YAML anchors and aliases in the workflow parser.
https://github.com/actions/runner/issues/1182#issuecomment-3150797791

A new helper function `resolveAlias` is introduced to dereference alias nodes before they are processed by the parsing functions. This function is called at the beginning of each parsing function to ensure that the parser is always working with the actual value nodes.

A new test case is added to verify that YAML anchors are correctly parsed. An existing test is also updated to ignore the `version` field in the SARIF output to make the tests more stable.