### PR TITLE
Fix type of `job.check_run_id` property

### DIFF
--- a/expr_sema.go
+++ b/expr_sema.go
@@ -252,7 +252,7 @@ var BuiltinGlobalVariableTypes = map[string]ExprType{
 	"env": NewMapObjectType(StringType{}), // env.<env_name>
 	// https://docs.github.com/en/actions/learn-github-actions/contexts#job-context
 	"job": NewStrictObjectType(map[string]ExprType{
-		"check_run_id": StringType{},
+		"check_run_id": NumberType{},
 		"container": NewStrictObjectType(map[string]ExprType{
 			"id":      StringType{},
 			"network": StringType{},


### PR DESCRIPTION
`job.check_run_id` property has type `number`, not `string`.

- GitHub Docs https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#job-context
- example run
  https://github.com/dhimmel/dump-actions-context/actions/runs/18170960955/job/51725241954#step:12:354

I asked why it has `number` type [here](https://github.com/orgs/community/discussions/8945#discussioncomment-14481081), but got no response from GitHub staff.