### PR TITLE
Enable artifact attestations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,13 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: write
-
 jobs:
   binaries:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
@@ -21,14 +22,19 @@ jobs:
         with:
           go-version: '1.25'
           check-latest: true
+      - name: Get version
+        run: echo VERSION="${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-checksums: ${{ format('./dist/actionlint_{0}_checksums.txt', env.VERSION) }}
       - name: Post-release download check
-        run: bash ./scripts/download-actionlint.bash "${GITHUB_REF#refs/tags/v}"
+        run: bash ./scripts/download-actionlint.bash "$VERSION"
       - name: Clone nested repository to make version bump commit
         uses: actions/checkout@v6
         with:
@@ -38,9 +44,8 @@ jobs:
       - name: Update version in download script
         run: |
           set -x
-          ver="${GITHUB_REF#refs/tags/v}"
           cd ./tmp-actionlint-for-update-ver
-          sed -i -E "s/version=\"[0-9]+\\.[0-9]+\\.[0-9]+\"/version=\"${ver}\"/" ./scripts/download-actionlint.bash
+          sed -i -E "s/version=\"[0-9]+\\.[0-9]+\\.[0-9]+\"/version=\"${VERSION}\"/" ./scripts/download-actionlint.bash
           git diff
           git add ./scripts/download-actionlint.bash
           git -c user.email='41898282+github-actions[bot]@users.noreply.github.com' -c user.name='github-actions[bot]' commit -m "update version to $ver in download-actionlint.bash"


### PR DESCRIPTION
This PR enables [artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) for new releases of actionlint, so that people can verify integrity of binaries downloaded from GitHub Releases.

- https://github.com/actions/attest-build-provenance
- https://goreleaser.com/customization/attestations/