### PR TITLE
Fix RawYAMLObject.Equals

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -510,6 +510,9 @@ func (o *RawYAMLObject) Kind() RawYAMLValueKind {
 func (o *RawYAMLObject) Equals(other RawYAMLValue) bool {
 	switch other := other.(type) {
 	case *RawYAMLObject:
+		if len(o.Props) != len(other.Props) {
+			return false
+		}
 		for n, p1 := range o.Props {
 			if p2, ok := other.Props[n]; !ok || !p1.Equals(p2) {
 				return false


### PR DESCRIPTION
This fixes comparing two RawYAMLObject's: Before, if `o` was something like `{a: 1, b: 2}` and `other` was `{a: 1, b: 2, c: 3}` then these would incorrectly be treated as equal because the algorithm only looked at the property keys in `o`. Checking that both have the same number of properties upfront fixes that.

closes #523 