### PR TITLE
Add support for entrypoint and command for service containers

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -789,6 +789,12 @@ type Container struct {
 	// Options is options string to run the container.
 	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontaineroptions
 	Options *String
+	// Command overrides Docker image's default command for service containers.
+	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idservicesservice_idcommand
+	Command *String
+	// Entrypoint overrides Docker image's default entrypoint for service containers.
+	// https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idservicesservice_identrypoint
+	Entrypoint *String
 	// Pos is a position in source.
 	Pos *Pos
 }

--- a/parse.go
+++ b/parse.go
@@ -1034,6 +1034,17 @@ func (p *parser) parseCredentials(pos *Pos, n *yaml.Node) *Credentials {
 // https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idcontainer
 func (p *parser) parseContainer(sec string, pos *Pos, n *yaml.Node) *Container {
 	ret := &Container{Pos: pos}
+	keys := []string{
+		"image",
+		"credentials",
+		"env",
+		"ports",
+		"volumes",
+		"options",
+	}
+	if sec == "services" {
+		keys = append(keys, "command", "entrypoint")
+	}
 
 	if n.Kind == yaml.ScalarNode {
 		// When you only specify a container image, you can omit the image keyword.
@@ -1055,15 +1066,20 @@ func (p *parser) parseContainer(sec string, pos *Pos, n *yaml.Node) *Container {
 			ret.Ports = p.parseStringSequence("volumes", e.val, true, false)
 		case "options":
 			ret.Options = p.parseString(e.val, true)
+		case "command":
+			if sec == "services" {
+				ret.Command = p.parseString(e.val, true)
+				continue
+			}
+			p.unexpectedKey(e.key, sec, keys)
+		case "entrypoint":
+			if sec == "services" {
+				ret.Entrypoint = p.parseString(e.val, true)
+				continue
+			}
+			p.unexpectedKey(e.key, sec, keys)
 		default:
-			p.unexpectedKey(e.key, sec, []string{
-				"image",
-				"credentials",
-				"env",
-				"ports",
-				"volumes",
-				"options",
-			})
+			p.unexpectedKey(e.key, sec, keys)
 		}
 	}
 

--- a/rule_expression.go
+++ b/rule_expression.go
@@ -501,6 +501,8 @@ func (rule *RuleExpression) checkContainer(c *Container, workflowKey, childWorkf
 	rule.checkStrings(c.Ports, workflowKey)
 	rule.checkStrings(c.Volumes, workflowKey)
 	rule.checkString(c.Options, workflowKey)
+	rule.checkString(c.Command, workflowKey)
+	rule.checkString(c.Entrypoint, workflowKey)
 }
 
 func (rule *RuleExpression) checkConcurrency(c *Concurrency, workflowKey string) {

--- a/testdata/err/case_sensitive_keys.out
+++ b/testdata/err/case_sensitive_keys.out
@@ -17,6 +17,6 @@ test.yaml:49:9: unexpected key "SHELL" for "run" section. expected one of "shell
 test.yaml:51:7: unexpected key "FAIL-FAST" for "strategy" section. expected one of "fail-fast", "matrix", "max-parallel" [syntax-check]
 test.yaml:53:7: unexpected key "IMAGE" for "container" section. expected one of "credentials", "env", "image", "options", "ports", "volumes" [syntax-check]
 test.yaml:56:9: unexpected key "USERNAME" for "credentials" section. expected one of "password", "username" [syntax-check]
-test.yaml:61:9: unexpected key "IMAGE" for "services" section. expected one of "credentials", "env", "image", "options", "ports", "volumes" [syntax-check]
+test.yaml:61:9: unexpected key "IMAGE" for "services" section. expected one of "command", "credentials", "entrypoint", "env", "image", "options", "ports", "volumes" [syntax-check]
 test.yaml:64:11: unexpected key "USERNAME" for "credentials" section. expected one of "password", "username" [syntax-check]
 test.yaml:68:9: unexpected key "RUN" for step to run shell command. expected one of "continue-on-error", "env", "id", "if", "name", "run", "shell", "timeout-minutes", "working-directory" [syntax-check]

--- a/testdata/err/context_availability.out
+++ b/testdata/err/context_availability.out
@@ -35,3 +35,5 @@
 /test\.yaml:228:15: context "env" is not allowed here\. .+ \[expression\]/
 /test\.yaml:228:35: context "runner" is not allowed here\. .+ \[expression\]/
 /test\.yaml:228:59: context "secrets" is not allowed here\. .+ \[expression\]/
+/test\.yaml:250:25: context "env" is not allowed here\. .+ \[expression\]/
+/test\.yaml:252:22: context "env" is not allowed here\. .+ \[expression\]/

--- a/testdata/err/context_availability.yaml
+++ b/testdata/err/context_availability.yaml
@@ -242,3 +242,14 @@ jobs:
       if: ${{ matrix.foo == 'a' && github.ref == 'foo' && vars.foo == 'foo' && needs.snapshot-err.outputs.foo == 'foo' && strategy.fail-fast && inputs.foo == 'foo' }}
     steps:
       - run: echo hi
+  test-service-overrides:
+    runs-on: ubuntu-latest
+    services:
+      nginx:
+        # ERROR at env
+        entrypoint: ${{ env.SERVICE_ENTRYPOINT }}
+        # ERROR at env
+        command: ${{ env.SERVICE_COMMAND }}
+        image: nginx
+    steps:
+      - run: echo hi

--- a/testdata/err/invalid_container_syntax.out
+++ b/testdata/err/invalid_container_syntax.out
@@ -19,3 +19,5 @@ test.yaml:81:19: "password" section in "container" section should be specified v
 test.yaml:87:7: "image" is missing in "services" section [syntax-check]
 test.yaml:97:9: both "username" and "password" must be specified in "credentials" section [syntax-check]
 test.yaml:110:21: "password" section in "redis" service should be specified via secrets. do not put password value directly [credentials]
+test.yaml:117:7: unexpected key "entrypoint" for "container" section. expected one of "credentials", "env", "image", "options", "ports", "volumes" [syntax-check]
+test.yaml:118:7: unexpected key "command" for "container" section. expected one of "credentials", "env", "image", "options", "ports", "volumes" [syntax-check]

--- a/testdata/err/invalid_container_syntax.yaml
+++ b/testdata/err/invalid_container_syntax.yaml
@@ -110,3 +110,11 @@ jobs:
           password: p@ssw0rd1234
     steps:
       - run: echo password should not be put in workflow
+  case15:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      entrypoint: bash
+      command: -lc 'echo hello'
+    steps:
+      - run: echo service-only keys must stay invalid for container

--- a/testdata/ok/container_syntax.yaml
+++ b/testdata/ok/container_syntax.yaml
@@ -32,6 +32,8 @@ jobs:
     services:
       redis:
         image: 'ghcr.io/rhysd/my-redis'
+        entrypoint: redis-server
+        command: --save 60 1
         env:
           FOO: foo
         ports:


### PR DESCRIPTION
Adds support for `jobs.<job_id>.services.<service_id>.entrypoint` and `jobs.<job_id>.services.<service_id>.command` - [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idservicesservice_identrypoint).

This keeps `jobs.<job_id>.container` unchanged, since GitHub Actions currently documents these keys only for service containers.

Closes #644.
