### PR TITLE
add config-secrets option to allow-list secrets in workflows

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,6 +64,11 @@ type Config struct {
 	// listed here as undefined config variables.
 	// https://docs.github.com/en/actions/learn-github-actions/variables
 	ConfigVariables []string `yaml:"config-variables"`
+	// ConfigSecrets is names of secrets used in the checked workflows. When this value is nil,
+	// property names of `secrets` context will not be checked. Otherwise actionlint will report a name which is not
+	// listed here as undefined secrets.
+	// https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
+	ConfigSecrets []string `yaml:"config-secrets"`
 	// Paths is a "paths" mapping in the configuration file. The keys are glob patterns to match file paths.
 	// And the values are corresponding configurations applied to the file paths.
 	Paths map[string]PathConfig `yaml:"paths"`
@@ -142,6 +147,10 @@ func writeDefaultConfigFile(path string) error {
 # organization. ` + "`null`" + ` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.
 config-variables: null
+
+# Secrets in array of strings defined in your repository or organization.
+# ` + "`null`" + ` means disabling secrets check. Empty array means no secret is allowed.
+config-secrets: null
 
 # Configuration for file paths. The keys are glob patterns to match to file
 # paths relative to the repository root. The values are the configurations for

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,12 @@ config-variables:
   - JOB_NAME
   - ENVIRONMENT_STAGE
 
+# Secrets in array of strings defined in your repository or organization.
+config-secrets:
+  - DEPLOY_TOKEN
+  - API_KEY
+  - ACCESS_TOKEN
+
 # Path-specific configurations.
 paths:
   # Glob pattern relative to the repository root for matching files. The path separator is always '/'.
@@ -49,6 +55,10 @@ paths:
     is available.
 - `config-variables`: [Configuration variables][vars]. When an array is set, actionlint will check `vars` properties strictly.
   An empty array means no variable is allowed. The default value `null` disables the check.
+- `config-secrets`: [Secrets][secrets]. When an array is set, actionlint will check `secrets` properties strictly against the
+  list. An empty array means no secret is allowed. The default value `null` disables the check. Note: this check only applies
+  when secrets are not explicitly declared in the workflow (e.g. via `secrets:` in `on.workflow_call`), since declared secrets
+  are already checked by their type.
 - `paths`: Configurations for specific file path patterns. This is a mapping from a glob pattern and the corresponding
   configuration.
   - `{glob}`: A file path glob pattern to apply the configuration. The path separator is always '/'. It is matched to the
@@ -75,4 +85,5 @@ vim .github/actionlint.yaml
 [Super-Linter]: https://github.com/super-linter/super-linter
 [pat]: https://pkg.go.dev/path#Match
 [vars]: https://docs.github.com/en/actions/learn-github-actions/variables
+[secrets]: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
 [doublestar]: https://github.com/bmatcuk/doublestar

--- a/expr_sema.go
+++ b/expr_sema.go
@@ -374,17 +374,19 @@ type ExprSemanticsChecker struct {
 	availableContexts     []string
 	availableSpecialFuncs []string
 	configVars            []string
+	configSecrets         []string
 }
 
 // NewExprSemanticsChecker creates new ExprSemanticsChecker instance. When checkUntrustedInput is
 // set to true, the checker will make use of possibly untrusted inputs error.
-func NewExprSemanticsChecker(checkUntrustedInput bool, configVars []string) *ExprSemanticsChecker {
+func NewExprSemanticsChecker(checkUntrustedInput bool, configVars []string, configSecrets []string) *ExprSemanticsChecker {
 	c := &ExprSemanticsChecker{
 		funcs:           BuiltinFuncSignatures,
 		vars:            BuiltinGlobalVariableTypes,
 		varsCopied:      false,
 		githubVarCopied: false,
 		configVars:      configVars,
+		configSecrets:   configSecrets,
 	}
 	if checkUntrustedInput {
 		c.untrusted = NewUntrustedInputChecker(BuiltinUntrustedInputs)
@@ -622,6 +624,9 @@ func (sema *ExprSemanticsChecker) checkObjectDeref(n *ObjectDerefNode) ExprType 
 			if v, ok := n.Receiver.(*VariableNode); ok && v.Name == "vars" {
 				sema.checkConfigVariables(n)
 			}
+			if v, ok := n.Receiver.(*VariableNode); ok && v.Name == "secrets" {
+				sema.checkConfigSecrets(n)
+			}
 			return ty.Mapped
 		}
 		if ty.IsStrict() {
@@ -710,6 +715,33 @@ func (sema *ExprSemanticsChecker) checkConfigVariables(n *ObjectDerefNode) {
 		"undefined configuration variable %q. defined configuration variables in actionlint.yaml are %s",
 		n.Property,
 		sortedQuotes(sema.configVars),
+	)
+}
+
+func (sema *ExprSemanticsChecker) checkConfigSecrets(n *ObjectDerefNode) {
+	if sema.configSecrets == nil {
+		return
+	}
+	if len(sema.configSecrets) == 0 {
+		sema.errorf(
+			n,
+			"no secret is allowed since the secrets list is empty in actionlint.yaml. you may forget adding the secret %q to the list",
+			n.Property,
+		)
+		return
+	}
+
+	for _, s := range sema.configSecrets {
+		if strings.EqualFold(s, n.Property) {
+			return
+		}
+	}
+
+	sema.errorf(
+		n,
+		"undefined secret %q. defined secrets in actionlint.yaml are %s",
+		n.Property,
+		sortedQuotes(sema.configSecrets),
 	)
 }
 

--- a/expr_sema_test.go
+++ b/expr_sema_test.go
@@ -22,9 +22,9 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 		secrets       *ObjectType
 		jobs          *ObjectType
 		availContexts []string
-		availSPFuncs   []string
-		configVars     []string
-		configSecrets  []string
+		availSPFuncs  []string
+		configVars    []string
+		configSecrets []string
 	}{
 		{
 			what:     "null",
@@ -856,13 +856,13 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 
 func TestExprSemanticsCheckError(t *testing.T) {
 	testCases := []struct {
-		what       string
-		input      string
-		expected   []string
-		funcs      map[string][]*FuncSignature
-		matrix     *ObjectType
-		steps      *ObjectType
-		needs      *ObjectType
+		what          string
+		input         string
+		expected      []string
+		funcs         map[string][]*FuncSignature
+		matrix        *ObjectType
+		steps         *ObjectType
+		needs         *ObjectType
 		availCtx      []string
 		availSP       []string
 		configVars    []string

--- a/expr_sema_test.go
+++ b/expr_sema_test.go
@@ -22,8 +22,9 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 		secrets       *ObjectType
 		jobs          *ObjectType
 		availContexts []string
-		availSPFuncs  []string
-		configVars    []string
+		availSPFuncs   []string
+		configVars     []string
+		configSecrets  []string
 	}{
 		{
 			what:     "null",
@@ -665,6 +666,23 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 			configVars: []string{"some_variable"},
 		},
 		{
+			what:     "secret",
+			input:    "secrets.MY_SECRET",
+			expected: StringType{},
+		},
+		{
+			what:          "known secret",
+			input:         "secrets.MY_SECRET",
+			expected:      StringType{},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
+			what:          "secret name is case insensitive",
+			input:         "secrets.MY_SECRET",
+			expected:      StringType{},
+			configSecrets: []string{"my_secret"},
+		},
+		{
 			what:     "narrow type of && operator by assumed value (#384)",
 			input:    "('foo' && 10) || 20",
 			expected: NumberType{},
@@ -793,7 +811,7 @@ func TestExprSemanticsCheckOK(t *testing.T) {
 				t.Fatal("Parse error:", tc.input)
 			}
 
-			c := NewExprSemanticsChecker(false, nil)
+			c := NewExprSemanticsChecker(false, tc.configVars, tc.configSecrets)
 			c.SetContextAvailability([]string{"github", "job", "jobs", "matrix", "steps", "needs", "env", "inputs", "secrets", "vars", "runner"})
 			if tc.funcs != nil {
 				c.funcs = tc.funcs
@@ -845,9 +863,10 @@ func TestExprSemanticsCheckError(t *testing.T) {
 		matrix     *ObjectType
 		steps      *ObjectType
 		needs      *ObjectType
-		availCtx   []string
-		availSP    []string
-		configVars []string
+		availCtx      []string
+		availSP       []string
+		configVars    []string
+		configSecrets []string
 	}{
 		{
 			what:  "undefined variable",
@@ -1314,6 +1333,22 @@ func TestExprSemanticsCheckError(t *testing.T) {
 			},
 		},
 		{
+			what:  "no secret is allowed",
+			input: "secrets.UNKNOWN_SECRET",
+			expected: []string{
+				"no secret is allowed since the secrets list is empty",
+			},
+			configSecrets: []string{},
+		},
+		{
+			what:  "unknown secret",
+			input: "secrets.UNKNOWN_SECRET",
+			expected: []string{
+				"undefined secret \"unknown_secret\".",
+			},
+			configSecrets: []string{"MY_SECRET"},
+		},
+		{
 			what:  "broken JSON value at fromJSON argument",
 			input: `fromJSON('{"foo": true')`,
 			expected: []string{
@@ -1352,7 +1387,7 @@ func TestExprSemanticsCheckError(t *testing.T) {
 				t.Fatal("Parse error:", tc.input)
 			}
 
-			c := NewExprSemanticsChecker(false, tc.configVars)
+			c := NewExprSemanticsChecker(false, tc.configVars, tc.configSecrets)
 			if tc.funcs != nil {
 				c.funcs = tc.funcs // Set functions for testing
 			}
@@ -1552,7 +1587,7 @@ func TestExprCompareOperandsCheck(t *testing.T) {
 						t.Fatal("Parse error:", input)
 					}
 
-					c := NewExprSemanticsChecker(false, nil)
+					c := NewExprSemanticsChecker(false, nil, nil)
 					c.vars = map[string]ExprType{
 						"number": NumberType{},
 						"string": StringType{},
@@ -1640,7 +1675,7 @@ func TestExprBuiltinFunctionSignatures(t *testing.T) {
 }
 
 func TestExprSemanticsCheckerUpdateMatrix(t *testing.T) {
-	c := NewExprSemanticsChecker(false, nil)
+	c := NewExprSemanticsChecker(false, nil, nil)
 	ty := NewEmptyObjectType()
 	prev := c.vars["matrix"]
 	c.UpdateMatrix(ty)
@@ -1655,7 +1690,7 @@ func TestExprSemanticsCheckerUpdateMatrix(t *testing.T) {
 }
 
 func TestExprSemanticsCheckerUpdateSteps(t *testing.T) {
-	c := NewExprSemanticsChecker(false, nil)
+	c := NewExprSemanticsChecker(false, nil, nil)
 	ty := NewEmptyObjectType()
 	prev := c.vars["steps"]
 	c.UpdateSteps(ty)
@@ -1671,7 +1706,7 @@ func TestExprSemanticsCheckerUpdateSteps(t *testing.T) {
 
 func TestExprSematincsCheckerUpdateDispatchInputsVarType(t *testing.T) {
 	ty := NewStrictObjectType(map[string]ExprType{"foo": NullType{}})
-	c := NewExprSemanticsChecker(false, nil)
+	c := NewExprSemanticsChecker(false, nil, nil)
 	c.UpdateDispatchInputs(ty)
 	o := c.vars["github"].(*ObjectType).Props["event"].(*ObjectType).Props["inputs"].(*ObjectType)
 	if _, ok := o.Props["foo"]; !ok {
@@ -1738,7 +1773,7 @@ func TestExprSemanticsCheckerUpdateInputsMultipleTimes(t *testing.T) {
 	for _, tc := range tests {
 		name := fmt.Sprintf("%v then %v", tc.first, tc.second)
 		t.Run(name, func(t *testing.T) {
-			c := NewExprSemanticsChecker(false, nil)
+			c := NewExprSemanticsChecker(false, nil, nil)
 			c.UpdateInputs(tc.first)
 			c.UpdateDispatchInputs(tc.second)
 			have := c.vars["inputs"]
@@ -2012,7 +2047,7 @@ func TestExprIsConstant(t *testing.T) {
 				t.Fatalf("Parse error for input %q: %s", tc.input, err)
 			}
 
-			c := NewExprSemanticsChecker(false, nil)
+			c := NewExprSemanticsChecker(false, nil, nil)
 			b := c.IsConstant(e)
 			if b != tc.isConst {
 				t.Fatalf("wanted %v but got %v for input %q", tc.isConst, b, tc.input)

--- a/expr_test.go
+++ b/expr_test.go
@@ -24,7 +24,7 @@ func TestExprSemanticsCheckRealWorld(t *testing.T) {
 			t.Errorf("%q caused parse error: %v", expr, err)
 			continue
 		}
-		c := NewExprSemanticsChecker(true, nil)
+		c := NewExprSemanticsChecker(true, nil, nil)
 		c.Check(root)
 	}
 	if err := s.Err(); err != nil {
@@ -82,7 +82,7 @@ func BenchmarkExprRealWorld(b *testing.B) {
 				if err != nil {
 					b.Fatalf("%q caused parse error: %v", expr, err)
 				}
-				NewExprSemanticsChecker(true, nil).Check(root)
+				NewExprSemanticsChecker(true, nil, nil).Check(root)
 			}
 		}
 	})
@@ -101,7 +101,7 @@ func BenchmarkExprRealWorld(b *testing.B) {
 	b.Run("Sema-untrust", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, t := range trees {
-				NewExprSemanticsChecker(true, nil).Check(t)
+				NewExprSemanticsChecker(true, nil, nil).Check(t)
 			}
 		}
 	})
@@ -109,7 +109,7 @@ func BenchmarkExprRealWorld(b *testing.B) {
 	b.Run("Sema-trust", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for _, t := range trees {
-				NewExprSemanticsChecker(false, nil).Check(t)
+				NewExprSemanticsChecker(false, nil, nil).Check(t)
 			}
 		}
 	})

--- a/fuzz/expr.go
+++ b/fuzz/expr.go
@@ -20,7 +20,7 @@ func FuzzExprParse(data []byte) int {
 		return 0
 	}
 
-	c := actionlint.NewExprSemanticsChecker(true, nil)
+	c := actionlint.NewExprSemanticsChecker(true, nil, nil)
 	c.Check(e)
 
 	return 1

--- a/rule_expression.go
+++ b/rule_expression.go
@@ -772,10 +772,12 @@ func (rule *RuleExpression) exprError(err *ExprError, lineBase, colBase int) {
 
 func (rule *RuleExpression) checkSemanticsOfExprNode(expr ExprNode, line, col int, checkUntrusted bool, workflowKey string) (ExprType, bool) {
 	var v []string
+	var s []string
 	if rule.config != nil {
 		v = rule.config.ConfigVariables
+		s = rule.config.ConfigSecrets
 	}
-	c := NewExprSemanticsChecker(checkUntrusted, v)
+	c := NewExprSemanticsChecker(checkUntrusted, v, s)
 	if rule.matrixTy != nil {
 		c.UpdateMatrix(rule.matrixTy)
 	}

--- a/rule_if_cond.go
+++ b/rule_if_cond.go
@@ -63,7 +63,7 @@ func (rule *RuleIfCond) checkExpression(pos *Pos, input string) {
 	i := strings.TrimSpace(input)
 	l := NewExprLexer(i + "}}")
 	if e, err := NewExprParser().Parse(l); err == nil {
-		if NewExprSemanticsChecker(false, nil).IsConstant(e) {
+		if NewExprSemanticsChecker(false, nil, nil).IsConstant(e) {
 			rule.Errorf(pos, "constant expression %q in condition. remove the if: section", i)
 		}
 	}

--- a/testdata/projects/config_secrets.out
+++ b/testdata/projects/config_secrets.out
@@ -1,0 +1,1 @@
+workflows/test.yaml:14:24: undefined secret "piyo". defined secrets in actionlint.yaml are "API_KEY", "MY_SECRET" [expression]

--- a/testdata/projects/config_secrets/actionlint.yaml
+++ b/testdata/projects/config_secrets/actionlint.yaml
@@ -1,0 +1,1 @@
+config-secrets: [MY_SECRET, API_KEY]

--- a/testdata/projects/config_secrets/workflows/test.yaml
+++ b/testdata/projects/config_secrets/workflows/test.yaml
@@ -1,0 +1,14 @@
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # These are listed
+      - run: echo '${{ secrets.MY_SECRET }}'
+      - run: echo '${{ secrets.API_KEY }}'
+      # Name is case-insensitive
+      - run: echo '${{ secrets.my_secret }}'
+      - run: echo '${{ secrets.My_Secret }}'
+      # ERROR: Undefined secret
+      - run: echo '${{ secrets.PIYO }}'


### PR DESCRIPTION
Fixes https://github.com/rhysd/actionlint/issues/609

I did use claude-code to open this because I'm not familiar at all with go. I tried to review the changes as best I could but apologize in advance if this is not good enough.

## Summary

- Adds a new `config-secrets` configuration option in `actionlint.yaml`, parallel to the existing `config-variables` option
- When set to an array of secret names, actionlint reports any `secrets.XXXX` access where XXXX is not in the list (case-insensitive)
- Default value `null` disables the check; an empty array disallows all secrets
- Updates `docs/config.md` with documentation and usage example

## Test plan

- [ ] New project-level integration test in `testdata/projects/config_secrets/`
- [ ] New unit tests in `TestExprSemanticsCheckOK` for `secret`, `known secret`, and `secret name is case insensitive`
- [ ] New unit tests in `TestExprSemanticsCheckError` for `no secret is allowed` and `unknown secret`
- [ ] All existing tests pass (`go test ./...`)
- [ ] `staticcheck ./...` passes cleanly