### PR TITLE
Add OCI image source label to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN go build -v -ldflags "-s -w -X github.com/rhysd/actionlint.version=${ACTIONL
 FROM koalaman/shellcheck-alpine:stable AS shellcheck
 
 FROM alpine:${ALPINE_VER}
+LABEL org.opencontainers.image.source="https://github.com/rhysd/actionlint"
+LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /go/src/app/actionlint /usr/local/bin/
 COPY --from=shellcheck /bin/shellcheck /usr/local/bin/shellcheck
 RUN apk add --no-cache py3-pyflakes


### PR DESCRIPTION
## Summary

Add standard OCI image labels to the final stage of `Dockerfile` so downstream
tooling (Renovate, Dependabot, Docker Hub image page, GHCR "Connect repository")
can auto-resolve this repository as the image source.

## Why

When consumers update `rhysd/actionlint` via Renovate or Dependabot, the
generated PR body currently has no repository link and no release notes
section — these tools read `org.opencontainers.image.source` from the image
metadata to discover the source repo.

Since actionlint also distributes a Docker image (via `docker://rhysd/actionlint`
and the pre-commit integration), consumers who pin to a specific Docker tag
for reproducible CI benefit from this change automatically.

## Changes

- Add `LABEL org.opencontainers.image.source` (points to this repo)
- Add `LABEL org.opencontainers.image.licenses="MIT"` (matches the project LICENSE)

## References

- [OCI image-spec — pre-defined annotation keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys)
- Same labels are used by projects like renovatebot/renovate and fluent/fluent-bit.

## Verification

- `docker build .` succeeds locally.
- `docker image inspect <tag> --format '{{json .Config.Labels}}'` shows the new labels:
  ```json
  {
    "org.opencontainers.image.licenses": "MIT",
    "org.opencontainers.image.source": "https://github.com/rhysd/actionlint"
  }
  ```
- `docker run --rm <tag> -version` works as before.
