### PR TITLE
Support user-global config from $XDG_CONFIG_HOME

### DIFF
--- a/config.go
+++ b/config.go
@@ -133,6 +133,34 @@ func loadRepoConfig(root string) (*Config, error) {
 	return nil, nil
 }
 
+// loadGlobalConfig reads the user-global config file from
+// $XDG_CONFIG_HOME/actionlint/actionlint.yaml (or actionlint.yml), falling back
+// to $HOME/.config/actionlint/ when $XDG_CONFIG_HOME is unset. It returns the
+// loaded config and its file path, or (nil, "", nil) when no config file exists.
+func loadGlobalConfig() (*Config, string, error) {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, "", nil
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	for _, f := range []string{"actionlint.yaml", "actionlint.yml"} {
+		p := filepath.Join(dir, "actionlint", f)
+		c, err := ReadConfigFile(p)
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			continue
+		case err != nil:
+			return nil, "", fmt.Errorf("could not parse global config file %q: %w", p, err)
+		default:
+			return c, p, nil
+		}
+	}
+	return nil, "", nil
+}
+
 func writeDefaultConfigFile(path string) error {
 	b := []byte(`self-hosted-runner:
   # Labels of self-hosted runner in array of strings.

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package actionlint
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -286,5 +287,144 @@ func TestConfigGenerateDefaultConfigFileError(t *testing.T) {
 	msg := err.Error()
 	if !strings.Contains(msg, "could not write default configuration file") {
 		t.Fatalf("unexpected error message: %q", msg)
+	}
+}
+
+func TestConfigLoadGlobalConfigOK(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	confDir := filepath.Join(dir, "actionlint")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "self-hosted-runner:\n  labels:\n    - foo\n    - bar\n"
+	want := filepath.Join(confDir, "actionlint.yaml")
+	if err := os.WriteFile(want, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, p, err := loadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("global config was not loaded")
+	}
+	if p != want {
+		t.Fatalf("wanted config path %q but have %q", want, p)
+	}
+	if diff := cmp.Diff(c.SelfHostedRunner.Labels, []string{"foo", "bar"}); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestConfigLoadGlobalConfigPrefersYamlOverYml(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	confDir := filepath.Join(dir, "actionlint")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "actionlint.yaml"), []byte("self-hosted-runner:\n  labels:\n    - yaml\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "actionlint.yml"), []byte("self-hosted-runner:\n  labels:\n    - yml\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, p, err := loadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("global config was not loaded")
+	}
+	if want := filepath.Join(confDir, "actionlint.yaml"); p != want {
+		t.Fatalf("wanted config path %q but have %q", want, p)
+	}
+	if diff := cmp.Diff(c.SelfHostedRunner.Labels, []string{"yaml"}); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestConfigLoadGlobalConfigYmlExtension(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	confDir := filepath.Join(dir, "actionlint")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(confDir, "actionlint.yml")
+	if err := os.WriteFile(want, []byte("self-hosted-runner:\n  labels:\n    - only-yml\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, p, err := loadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("global config was not loaded")
+	}
+	if p != want {
+		t.Fatalf("wanted config path %q but have %q", want, p)
+	}
+}
+
+func TestConfigLoadGlobalConfigNotFound(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	c, p, err := loadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c != nil || p != "" {
+		t.Fatalf("wanted no global config but have config=%v and path=%q", c, p)
+	}
+}
+
+func TestConfigLoadGlobalConfigParseError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	confDir := filepath.Join(dir, "actionlint")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "actionlint.yaml"), []byte("this: [is not: valid\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := loadGlobalConfig()
+	if err == nil {
+		t.Fatal("error did not occur")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "global config file") {
+		t.Fatalf("unexpected error message: %q", msg)
+	}
+}
+
+func TestConfigLoadGlobalConfigHomeDirFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", home)
+	// os.UserHomeDir reads %USERPROFILE% instead of $HOME on Windows.
+	t.Setenv("USERPROFILE", home)
+	confDir := filepath.Join(home, ".config", "actionlint")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(confDir, "actionlint.yaml")
+	if err := os.WriteFile(want, []byte("self-hosted-runner:\n  labels:\n    - home\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, p, err := loadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("global config was not loaded from $HOME/.config")
+	}
+	if p != want {
+		t.Fatalf("wanted config path %q but have %q", want, p)
 	}
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,23 @@ paths:
       expressions. When one of the patterns matches the error message, the error will be ignored. It's similar to the
       `-ignore` command line option.
 
+## Configuration file location and priority
+
+actionlint looks for a configuration file in the following order and uses the **first** one found. Configurations
+are not merged:
+
+1. The file passed via the `-config-file` command line option.
+2. `actionlint.yaml` (or `actionlint.yml`) in the repository's `.github` directory. actionlint locates the project by
+   searching upwards from the linted file's directory.
+3. The user-global configuration at `$XDG_CONFIG_HOME/actionlint/actionlint.yaml` (or `actionlint.yml`). When
+   `$XDG_CONFIG_HOME` is not set, `$HOME/.config/actionlint/actionlint.yaml` is used instead, following the
+   [XDG Base Directory specification][xdg].
+
+The user-global configuration is useful for personal or organization-wide defaults shared across many repositories
+(for example via dotfiles), or for CI base images that need a baseline configuration without injecting a config file
+into every checkout. A repository's own `.github/actionlint.yaml` always takes precedence over the global configuration,
+so per-repository settings are never overridden by the global defaults.
+
 ## Generate the initial configuration
 
 You don't need to write the first configuration file by your hand. `actionlint` command can generate a default configuration
@@ -72,6 +89,7 @@ vim .github/actionlint.yaml
 
 [Checks](checks.md) | [Installation](install.md) | [Usage](usage.md) | [Go API](api.md) | [References](reference.md)
 
+[xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
 [Super-Linter]: https://github.com/super-linter/super-linter
 [pat]: https://pkg.go.dev/path#Match
 [vars]: https://docs.github.com/en/actions/learn-github-actions/variables

--- a/linter.go
+++ b/linter.go
@@ -75,7 +75,8 @@ type LinterOptions struct {
 	// messages. When an error is matched, the error is ignored.
 	IgnorePatterns []string
 	// ConfigFile is a path to config file. Empty string means no config file path is given. In
-	// the case, actionlint will try to read config from .github/actionlint.yaml.
+	// the case, actionlint will try to read config from the repository's .github/actionlint.yaml,
+	// then from $XDG_CONFIG_HOME/actionlint/actionlint.yaml ($HOME/.config when unset).
 	ConfigFile string
 	// Format is a custom template to format error messages. It must follow Go Template format and
 	// contain at least one {{ }} placeholder. https://pkg.go.dev/text/template
@@ -106,6 +107,7 @@ type Linter struct {
 	ignorePats     IgnorePatterns
 	stdin          string
 	defaultConfig  *Config
+	globalConfig   *Config
 	errFmt         *ErrorFormatter
 	cwd            string
 	onRulesCreated func([]Rule) []Rule
@@ -149,6 +151,18 @@ func NewLinter(out io.Writer, opts *LinterOptions) (*Linter, error) {
 		cfg = c
 	}
 
+	// Load the user-global config as a fallback for projects which have no
+	// .github/actionlint.yaml. The -config-file option takes precedence over it.
+	var globalCfg *Config
+	var globalCfgPath string
+	if opts.ConfigFile == "" {
+		c, p, err := loadGlobalConfig()
+		if err != nil {
+			return nil, err
+		}
+		globalCfg, globalCfgPath = c, p
+	}
+
 	ignore := make([]*regexp.Regexp, 0, len(opts.IgnorePatterns))
 	for _, s := range opts.IgnorePatterns {
 		r, err := regexp.Compile(s)
@@ -190,12 +204,16 @@ func NewLinter(out io.Writer, opts *LinterOptions) (*Linter, error) {
 		ignore,
 		stdin,
 		cfg,
+		globalCfg,
 		formatter,
 		cwd,
 		opts.OnRulesCreated,
 	}
 
 	l.debug("Create a Linter instance with option %#v", opts)
+	if globalCfgPath != "" {
+		l.debug("Loaded user-global config from %q", globalCfgPath)
+	}
 	return l, nil
 }
 
@@ -531,12 +549,14 @@ func (l *Linter) check(
 		l.log("Using project at", project.RootDir())
 	}
 
+	// Config priority: -config-file option, then repository config, then user-global config
 	var cfg *Config
 	if l.defaultConfig != nil {
-		// `-config-file` option has higher priority than repository config file
 		cfg = l.defaultConfig
-	} else if project != nil {
+	} else if project != nil && project.Config() != nil {
 		cfg = project.Config()
+	} else {
+		cfg = l.globalConfig
 	}
 	if cfg != nil {
 		l.debug("Config: %#v", cfg)

--- a/linter_test.go
+++ b/linter_test.go
@@ -19,6 +19,19 @@ import (
 	"golang.org/x/sys/execabs"
 )
 
+func TestMain(m *testing.M) {
+	// Point $XDG_CONFIG_HOME at an empty directory so that tests do not pick up
+	// a user-global config file on the machine running them.
+	dir, err := os.MkdirTemp("", "actionlint-test-xdg-config")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("XDG_CONFIG_HOME", dir)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
 type testErrorReader struct{}
 
 func (r testErrorReader) Read(p []byte) (int, error) {
@@ -916,5 +929,89 @@ func BenchmarkLintRepository(b *testing.B) {
 		if len(errs) > 0 {
 			b.Fatal(errs)
 		}
+	}
+}
+
+func TestLinterGlobalConfigFallback(t *testing.T) {
+	const wf = `on: push
+jobs:
+  test:
+    runs-on: my-custom-runner
+    steps:
+      - run: echo hi
+`
+	// Path outside any Git repository so that no repository config is found
+	path := filepath.Join(t.TempDir(), "no-such-workflow.yaml")
+
+	mentionsLabel := func(errs []*Error) bool {
+		for _, e := range errs {
+			if strings.Contains(e.Message, "my-custom-runner") {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Without any config, the label is unknown
+	linter, err := NewLinter(io.Discard, &LinterOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	errs, err := linter.Lint(path, []byte(wf), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mentionsLabel(errs) {
+		t.Fatalf("wanted an unknown-label error without global config but got: %v", errs)
+	}
+
+	// With a global config listing the label, the error is suppressed
+	linter, err = NewLinter(io.Discard, &LinterOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	linter.globalConfig = &Config{}
+	linter.globalConfig.SelfHostedRunner.Labels = []string{"my-custom-runner"}
+	errs, err = linter.Lint(path, []byte(wf), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mentionsLabel(errs) {
+		t.Fatalf("global config should have suppressed the unknown-label error but got: %v", errs)
+	}
+}
+
+func TestLinterConfigFilePriorityOverGlobalConfig(t *testing.T) {
+	const wf = `on: push
+jobs:
+  test:
+    runs-on: my-custom-runner
+    steps:
+      - run: echo hi
+`
+	path := filepath.Join(t.TempDir(), "no-such-workflow.yaml")
+
+	linter, err := NewLinter(io.Discard, &LinterOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The config from -config-file lists no labels, so the label must remain
+	// unknown even though the global config lists it
+	linter.defaultConfig = &Config{}
+	linter.globalConfig = &Config{}
+	linter.globalConfig.SelfHostedRunner.Labels = []string{"my-custom-runner"}
+
+	errs, err := linter.Lint(path, []byte(wf), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "my-custom-runner") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("label should remain unknown since -config-file takes priority over global config but got: %v", errs)
 	}
 }


### PR DESCRIPTION
Here is suggestion PR for this function.

Add a user-global configuration source loaded from $XDG_CONFIG_HOME/actionlint/actionlint.yaml (or .yml), falling back to $HOME/.config/actionlint/actionlint.yaml when $XDG_CONFIG_HOME is unset, per the XDG Base Directory specification.

Config discovery is now, first found wins (no merging):
  1. -config-file option
  2. repository .github/actionlint.yaml
  3. user-global $XDG_CONFIG_HOME/actionlint/actionlint.yaml

This lets users keep personal/organization-wide defaults across many repositories (e.g. via dotfiles) and lets CI base images carry a baseline config without injecting a file into every checkout. A repository's own .github/actionlint.yaml always takes precedence.

I think config merging would be a future, natural PR for this, but .. one step at a time.

Closes #675